### PR TITLE
Backend/tie tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060000)
 
 # Fetch Qx (build and import from source)
 include(OB/FetchQx)
-fetch_qx("f6f0d573622d1a712b4aa809f21b5d8b291d83fb")
+fetch_qx("a67682b6e94c7dd686df7e475eb91406f92efbfa")
 
 # Fetch Neargye's Magic Enum
 include(OB/FetchMagicEnum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ add_subdirectory(app)
 if(STARCALC_TESTS)
     enable_testing()
     set(TESTS_TARGET_PREFIX ${PROJECT_NAME_LC})
+    set(TESTS_COMMON_ALIAS_NAME ${PROJECT_NAME}::TestCommon)
     add_subdirectory(tests)
 endif()
 

--- a/lib/include/star/election.h
+++ b/lib/include/star/election.h
@@ -89,6 +89,7 @@ public:
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     Builder& wBallot(const Voter& voter, const QList<Vote>& votes);
+    void reset();
     Election build();
 };
 

--- a/lib/src/election.cpp
+++ b/lib/src/election.cpp
@@ -103,6 +103,13 @@ Election::Builder& Election::Builder::wBallot(const Voter& voter, const QList<Vo
     return *this;
 }
 
+void Election::Builder::reset()
+{
+    QString name = mConstruct.mName;
+    mConstruct = Election();
+    mConstruct.mName = name;
+}
+
 Election Election::Builder::build()
 {
     // Form rankings

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(full_reference_election)
+add_subdirectory(ties)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(_common)
 add_subdirectory(full_reference_election)
 add_subdirectory(ties)

--- a/tests/_common/CMakeLists.txt
+++ b/tests/_common/CMakeLists.txt
@@ -1,0 +1,21 @@
+#=== TESTS INTERFACE HELPER LIB ===
+
+# Setup lib target
+set(target_name "${TESTS_TARGET_PREFIX}_tst_common")
+add_library(${target_name} INTERFACE)
+add_library(${TESTS_COMMON_ALIAS_NAME} ALIAS ${target_name})
+
+target_sources(${target_name}
+    PRIVATE
+        include/star_test_common.h
+)
+
+target_include_directories(${target_name}
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+target_link_libraries(${target_name}
+    INTERFACE
+        StarCalc::Base
+)

--- a/tests/_common/include/star_test_common.h
+++ b/tests/_common/include/star_test_common.h
@@ -1,0 +1,23 @@
+#include <star/election.h>
+#include <star/reference.h>
+
+// Macros
+#define C_STR(q_str) q_str.toStdString().c_str()
+
+// Test debug helpers (enables more helpful print-outs from test failures)
+namespace Star
+{
+
+char* toString(const ExpectedElectionResult& eer)
+{
+    QString string = "W = {" + eer.winners().join(", ") +  "}  | R = {" + eer.runnerUps().join(", ") + '}';
+    return qstrdup(string.toUtf8().constData());
+}
+
+char* toString(const ElectionResult& er)
+{
+    QString string = "W = {" + er.winners().join(", ") +  "}  | R = {" + er.runnerUps().join(", ") + '}';
+    return qstrdup(string.toUtf8().constData());
+}
+
+}

--- a/tests/full_reference_election/CMakeLists.txt
+++ b/tests/full_reference_election/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(${target_name}
 	PRIVATE 
 		Qt6::Test
 		StarCalc::Base
+                StarCalc::TestCommon
 )
 
 # Bundle test data

--- a/tests/full_reference_election/tst_full_reference_election.cpp
+++ b/tests/full_reference_election/tst_full_reference_election.cpp
@@ -5,8 +5,8 @@
 #include <star/reference.h>
 #include <star/calculator.h>
 
-// Macros
-#define C_STR(q_str) q_str.toStdString().c_str()
+// Test Includes
+#include <star_test_common.h>
 
 class tst_full_reference_election : public QObject
 {

--- a/tests/ties/CMakeLists.txt
+++ b/tests/ties/CMakeLists.txt
@@ -1,0 +1,15 @@
+#================= Common Build =========================
+
+# Allow includes relative to source root
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Setup test target
+set(test_name "tst_ties")
+set(target_name "${TESTS_TARGET_PREFIX}_${test_name}")
+add_executable(${target_name} ${test_name}.cpp)
+add_test(NAME ${target_name} COMMAND ${target_name})
+target_link_libraries(${target_name}
+	PRIVATE 
+		Qt6::Test
+		StarCalc::Base
+)

--- a/tests/ties/CMakeLists.txt
+++ b/tests/ties/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_libraries(${target_name}
 	PRIVATE 
 		Qt6::Test
 		StarCalc::Base
+                StarCalc::TestCommon
 )

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -39,10 +39,10 @@ void tst_ties::all_tie_cases_data()
     QTest::addColumn<std::optional<Star::Calculator::ExtendedTiebreakMethod>>("extended_method");
 
     // Candidates
-    QString candidateOne = "CanOne";
-    QString candidateTwo = "CanTwo";
-    QString candidateThree = "CanThree";
-    QString candidateFour = "CanFour";
+    QString candidate1 = "CanOne";
+    QString candidate2 = "CanTwo";
+    QString candidate3 = "CanThree";
+    QString candidate4 = "CanFour";
 
     // Helper
     auto addTestRow = [&](const QString& testName,
@@ -63,28 +63,53 @@ void tst_ties::all_tie_cases_data()
 
     //-Populate test table rows with each case-----------------------------
 
-    addTestRow("Preliminary - First 2-way place tie",
+    addTestRow("Preliminary - First place 2-way tie",
                {
                    {
-                       {.nominee = candidateOne, .score = 0},
-                       {.nominee = candidateTwo, .score = 4},
-                       {.nominee = candidateThree, .score = 0},
-                       {.nominee = candidateFour, .score = 0}
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0}
                    },
                    {
-                       {.nominee = candidateOne, .score = 2},
-                       {.nominee = candidateTwo, .score = 1},
-                       {.nominee = candidateThree, .score = 3},
-                       {.nominee = candidateFour, .score = 0}
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 0}
                    },
                    {
-                       {.nominee = candidateOne, .score = 3},
-                       {.nominee = candidateTwo, .score = 0},
-                       {.nominee = candidateThree, .score = 1},
-                       {.nominee = candidateFour, .score = 0}
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 0}
                    }
                },
-               Star::ExpectedElectionResult({candidateOne}, {candidateTwo}),
+               Star::ExpectedElectionResult({candidate1}, {candidate2}),
+               std::nullopt
+    );
+
+    addTestRow("Preliminary - First place N-way tie, successful break,",
+               {
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate4}),
                std::nullopt
     );
 }

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -42,6 +42,7 @@ void tst_ties::all_tie_cases_data()
     QString candidate2 = "CanTwo";
     QString candidate3 = "CanThree";
     QString candidate4 = "CanFour";
+    QString candidate5 = "CanFive";
 
     // Helper
     auto addTestRow = [&](const QString& testName,
@@ -184,6 +185,253 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - First place N-way tie, successful break,",
+               {
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - First place N-way tie, unsuccessful break, single fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 4},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 4},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3, candidate4}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - First place N-way tie, unsuccessful break, no fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3, candidate4}, {}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - Second place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               std::nullopt
+    );
+
+    addTestRow("Runoff - Second place N-way tie, unsuccessful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
                std::nullopt
     );
 }

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -5,9 +5,10 @@
 #include <star/reference.h>
 #include <star/calculator.h>
 
-// Macros
-#define C_STR(q_str) q_str.toStdString().c_str()
+// Test Includes
+#include <star_test_common.h>
 
+// Test
 class tst_ties : public QObject
 {
     Q_OBJECT

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -88,7 +88,7 @@ void tst_ties::all_tie_cases_data()
                std::nullopt
     );
 
-    addTestRow("Preliminary - First place N-way tie, successful break,",
+    addTestRow("Preliminary - First place N-way tie, successful break",
                {
                    {
                        {.nominee = candidate1, .score = 0},
@@ -113,7 +113,7 @@ void tst_ties::all_tie_cases_data()
                std::nullopt
     );
 
-    addTestRow("Preliminary - First place N-way tie, unsuccessful break,",
+    addTestRow("Preliminary - First place N-way tie, unsuccessful break",
                {
                    {
                        {.nominee = candidate1, .score = 1},
@@ -138,7 +138,7 @@ void tst_ties::all_tie_cases_data()
                std::nullopt
     );
 
-    addTestRow("Preliminary - Second place N-way tie, successful break,",
+    addTestRow("Preliminary - Second place N-way tie, successful break",
                {
                    {
                        {.nominee = candidate1, .score = 0},
@@ -163,7 +163,7 @@ void tst_ties::all_tie_cases_data()
                std::nullopt
     );
 
-    addTestRow("Preliminary - Second place N-way tie, unsuccessful break,",
+    addTestRow("Preliminary - Second place N-way tie, unsuccessful break",
                {
                    {
                        {.nominee = candidate1, .score = 0},
@@ -188,7 +188,7 @@ void tst_ties::all_tie_cases_data()
                std::nullopt
     );
 
-    addTestRow("Runoff - First place N-way tie, successful break,",
+    addTestRow("Runoff - First place N-way tie, successful break",
                {
                    {
                        {.nominee = candidate1, .score = 3},
@@ -433,6 +433,536 @@ void tst_ties::all_tie_cases_data()
                },
                Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
                std::nullopt
+    );
+
+    addTestRow("Extended [FiveStar] - First place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2}, {candidate1}),
+               Star::Calculator::FiveStar
+    );
+
+    addTestRow("Extended [FiveStar] - First place N-way tie, unsuccessful break, single fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3}),
+               Star::Calculator::FiveStar
+    );
+
+        addTestRow("Extended [FiveStar] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+                   {
+                       {
+                           {.nominee = candidate1, .score = 5},
+                           {.nominee = candidate2, .score = 3},
+                           {.nominee = candidate3, .score = 4},
+                           {.nominee = candidate4, .score = 3},
+                           {.nominee = candidate5, .score = 3}
+                       },
+                       {
+                           {.nominee = candidate1, .score = 2},
+                           {.nominee = candidate2, .score = 5},
+                           {.nominee = candidate3, .score = 3},
+                           {.nominee = candidate4, .score = 3},
+                           {.nominee = candidate5, .score = 2}
+                       },
+                       {
+                           {.nominee = candidate1, .score = 3},
+                           {.nominee = candidate2, .score = 2},
+                           {.nominee = candidate3, .score = 4},
+                           {.nominee = candidate4, .score = 3},
+                           {.nominee = candidate5, .score = 3}
+                       },
+                       {
+                           {.nominee = candidate1, .score = 3},
+                           {.nominee = candidate2, .score = 2},
+                           {.nominee = candidate3, .score = 2},
+                           {.nominee = candidate4, .score = 5},
+                           {.nominee = candidate5, .score = 2}
+                       },
+                       {
+                           {.nominee = candidate1, .score = 5},
+                           {.nominee = candidate2, .score = 3},
+                           {.nominee = candidate3, .score = 4},
+                           {.nominee = candidate4, .score = 2},
+                           {.nominee = candidate5, .score = 5}
+                       },
+                       {
+                           {.nominee = candidate1, .score = 2},
+                           {.nominee = candidate2, .score = 5},
+                           {.nominee = candidate3, .score = 3},
+                           {.nominee = candidate4, .score = 4},
+                           {.nominee = candidate5, .score = 5}
+                       }
+                   },
+                   Star::ExpectedElectionResult({candidate2, candidate1}, {candidate4}),
+                   Star::Calculator::FiveStar
+        );
+
+    addTestRow("Extended [FiveStar] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 4},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3, candidate4}),
+               Star::Calculator::FiveStar
+    );
+
+    addTestRow("Extended [FiveStar] - First place N-way tie, unsuccessful break, no fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1, candidate4}, {}),
+               Star::Calculator::FiveStar
+    );
+
+    addTestRow("Extended [FiveStar] - Second place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3}),
+               Star::Calculator::FiveStar
+    );
+
+    addTestRow("Extended [FiveStar] - Second place N-way tie, unsuccessful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
+               Star::Calculator::FiveStar
+    );
+
+    addTestRow("Extended [Condorcet] - First place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 3},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 4},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate2}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, single fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate5}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2},
+                       {.nominee = candidate5, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5},
+                       {.nominee = candidate5, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0},
+                       {.nominee = candidate5, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3, candidate5}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, no fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 0}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 0}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate2, candidate3, candidate1}, {}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - Second place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               Star::Calculator::Condorcet
+    );
+
+    addTestRow("Extended [Condorcet] - Second place N-way tie, unsuccessful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
+               Star::Calculator::Condorcet
     );
 }
 

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -2,7 +2,6 @@
 #include <QtTest>
 
 // Base Includes
-#include <star/reference.h>
 #include <star/calculator.h>
 
 // Test Includes

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -111,6 +111,81 @@ void tst_ties::all_tie_cases_data()
                Star::ExpectedElectionResult({candidate1}, {candidate4}),
                std::nullopt
     );
+
+    addTestRow("Preliminary - First place N-way tie, unsuccessful break,",
+               {
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate4}),
+               std::nullopt
+    );
+
+    addTestRow("Preliminary - Second place N-way tie, successful break,",
+               {
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 0}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               std::nullopt
+    );
+
+    addTestRow("Preliminary - Second place N-way tie, unsuccessful break,",
+               {
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 3}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3}, {candidate1}),
+               std::nullopt
+    );
 }
 
 void tst_ties::all_tie_cases()

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -1,0 +1,108 @@
+// Qt Includes
+#include <QtTest>
+
+// Base Includes
+#include <star/reference.h>
+#include <star/calculator.h>
+
+// Macros
+#define C_STR(q_str) q_str.toStdString().c_str()
+
+class tst_ties : public QObject
+{
+    Q_OBJECT
+
+public:
+    tst_ties();
+
+private slots:
+    // Init
+//    void initTestCase();
+//    void cleanupTestCase();
+
+    // Test cases
+    void all_tie_cases_data();
+    void all_tie_cases();
+
+};
+
+tst_ties::tst_ties() {}
+//void tst_ties::initTestCase() {}
+//void tst_ties::cleanupTestCase() {}
+
+void tst_ties::all_tie_cases_data()
+{
+    // Setup test table
+    QTest::addColumn<Star::Election>("election");
+    QTest::addColumn<Star::ExpectedElectionResult>("expected_result");
+    QTest::addColumn<std::optional<Star::Calculator::ExtendedTiebreakMethod>>("extended_method");
+
+    // Candidates
+    QString candidateOne = "CanOne";
+    QString candidateTwo = "CanTwo";
+    QString candidateThree = "CanThree";
+    QString candidateFour = "CanFour";
+
+    // Helper
+    auto addTestRow = [&](const QString& testName,
+                          QList<QList<Star::Election::Vote>> votes,
+                          Star::ExpectedElectionResult results,
+                          std::optional<Star::Calculator::ExtendedTiebreakMethod> extendedMethod){
+
+        static Star::Election::Builder builder("");
+
+        for(QList<Star::Election::Vote> voteList : votes)
+            builder.wBallot({}, voteList);
+
+        Star::Election election = builder.build();
+
+        QTest::newRow(C_STR(testName)) << election << results << extendedMethod;
+        builder.reset();
+    };
+
+    //-Populate test table rows with each case-----------------------------
+
+    addTestRow("Preliminary - First 2-way place tie",
+               {
+                   {
+                       {.nominee = candidateOne, .score = 0},
+                       {.nominee = candidateTwo, .score = 4},
+                       {.nominee = candidateThree, .score = 0},
+                       {.nominee = candidateFour, .score = 0}
+                   },
+                   {
+                       {.nominee = candidateOne, .score = 2},
+                       {.nominee = candidateTwo, .score = 1},
+                       {.nominee = candidateThree, .score = 3},
+                       {.nominee = candidateFour, .score = 0}
+                   },
+                   {
+                       {.nominee = candidateOne, .score = 3},
+                       {.nominee = candidateTwo, .score = 0},
+                       {.nominee = candidateThree, .score = 1},
+                       {.nominee = candidateFour, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidateOne}, {candidateTwo}),
+               std::nullopt
+    );
+}
+
+void tst_ties::all_tie_cases()
+{
+    // Fetch data from test table
+    QFETCH(Star::Election, election);
+    QFETCH(Star::ExpectedElectionResult, expected_result);
+    QFETCH(std::optional<Star::Calculator::ExtendedTiebreakMethod>, extended_method);
+
+    // Setup calculator
+    static Star::Calculator calc;
+    calc.setElection(&election);
+    calc.setExtraTiebreakMethod(extended_method);
+
+    // Compare results
+    QCOMPARE(calc.calculateResult(), expected_result);
+}
+
+QTEST_APPLESS_MAIN(tst_ties)
+#include "tst_ties.moc"


### PR DESCRIPTION
Essentially covers all tie-cases, except for useless watering down of a few, such as making multiple tests for a failed tiebreak leaving 2 tied candidates vs. 3 tied candidates (or 4, 5, etc).