### PR TITLE
Use QSet<QString> for candidate groups when order doesn't matter

### DIFF
--- a/app/src/resultspresenter.cpp
+++ b/app/src/resultspresenter.cpp
@@ -7,6 +7,7 @@
 // Qx Includes
 #include <qx/core/qx-iostream.h>
 #include <qx/core/qx-table.h>
+#include <qx/core/qx-string.h>
 
 // Using
 using Qx::cout;
@@ -41,11 +42,11 @@ void ResultPresenter::printElectionResult(const Star::ElectionResult& result)
     QString category = result.election()->name();
     QStringList nominees = result.election()->nominees();
     QString winnerStr = result.winners().size() > 1 ?
-                        WINNER_MULTI_TEMPLATE.arg(result.winners().join(R"(", ")")) :
-                        WINNER_SINGLE_TEMPLATE.arg(result.winners().front());
+                        WINNER_MULTI_TEMPLATE.arg(Qx::String::join(result.winners(), R"(", ")")) :
+                        WINNER_SINGLE_TEMPLATE.arg(*result.winners().constBegin());
     QString runnerUpStr = result.winners().size() > 1 ?
-                          RUNNERUP_MULTI_TEMPLATE.arg(result.runnerUps().join(R"(", ")")) :
-                          RUNNERUP_SINGLE_TEMPLATE.arg(result.runnerUps().front());
+                          RUNNERUP_MULTI_TEMPLATE.arg(Qx::String::join(result.runnerUps(), R"(", ")")) :
+                          RUNNERUP_SINGLE_TEMPLATE.arg(*result.runnerUps().constBegin());
 
     // Print category
     cout << HEADING_CATEGORY.arg(category) << endl << endl;
@@ -65,7 +66,7 @@ void ResultPresenter::printElectionResult(const Star::ElectionResult& result)
 
     // Print raw score rankings
     for(const Rank& rank : result.election()->scoreRankings())
-        cout << RAW_SCORE_TEMPLATE.arg(rank.nominees.join(R"(", ")")).arg(rank.value) << endl;
+        cout << RAW_SCORE_TEMPLATE.arg(Qx::String::join(rank.nominees, R"(", ")")).arg(rank.value) << endl;
     cout << endl;
 
     // Wait on user confirm
@@ -101,8 +102,8 @@ void ResultPresenter::printSummary()
 
         // Category, winner, runner-up
         summaryTable.at(row, 0) = ' ' + result.election()->name() + ' ';
-        summaryTable.at(row, 1) = SUMMARY_LIST_ITEM.arg(result.winners().join(R"(", ")"));
-        summaryTable.at(row, 2) = SUMMARY_LIST_ITEM.arg(result.runnerUps().join(R"(", ")"));
+        summaryTable.at(row, 1) = SUMMARY_LIST_ITEM.arg(Qx::String::join(result.winners(), R"(", ")"));
+        summaryTable.at(row, 2) = SUMMARY_LIST_ITEM.arg(Qx::String::join(result.runnerUps(), R"(", ")"));
     }
 
     // Determine field widths

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -116,25 +116,25 @@ public:
 //-Instance Functions-------------------------------------------------------------------------------------------------
 private:
     // Main steps
-    QStringList determinePreliminaryLeaders();
-    QPair<QStringList, QStringList> performPrimaryRunoff(const QStringList& preliminaryLeaders);
-    QPair<QStringList, QStringList> performExtendedTiebreak(QStringList initialWinners, QStringList initialRunnerUps, ExtendedTiebreakMethod method);
+    QSet<QString> determinePreliminaryLeaders();
+    QPair<QSet<QString>, QSet<QString>> performPrimaryRunoff(const QSet<QString>& preliminaryLeaders);
+    QPair<QSet<QString>, QSet<QString>> performExtendedTiebreak(QSet<QString> initialWinners, QSet<QString> initialRunnerUps, ExtendedTiebreakMethod method);
 
     // Utility
-    QList<Rank> rankByPreference(const QStringList& nominees);
-    QList<Rank> rankByScore(const QStringList& nominees);
-    QList<Rank> rankByVotesOfMaxScore(const QStringList& nominees);
-    QList<Rank> rankByHeadToHeadWins(const QStringList& nominees);
+    QList<Rank> rankByPreference(const QSet<QString>& nominees);
+    QList<Rank> rankByScore(const QSet<QString>& nominees);
+    QList<Rank> rankByVotesOfMaxScore(const QSet<QString>& nominees);
+    QList<Rank> rankByHeadToHeadWins(const QSet<QString>& nominees);
 
-    QPair<QStringList, QStringList> rankBasedTiebreak(const QList<Rank>& rankings, const QString& note);
-    QPair<QStringList, QStringList> breakScoreTie(const QStringList& nominees);
-    QPair<QStringList, QStringList> breakPreferenceTie(const QStringList& nominees);
-    QPair<QStringList, QStringList> breakExtendedTieFiveStar(const QStringList& nominees);
-    QPair<QStringList, QStringList> breakExtendedTieCondorcet(const QStringList& nominees);
+    QPair<QSet<QString>, QSet<QString>> rankBasedTiebreak(const QList<Rank>& rankings, const QString& note);
+    QPair<QSet<QString>, QSet<QString>> breakScoreTie(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakPreferenceTie(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieFiveStar(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieCondorcet(const QSet<QString>& nominees);
 
     // Logging
-    QString createNomineeGeneralListString(const QStringList& nominees);
-    QString createNomineeToalScoreListString(const QStringList& nominees);
+    QString createNomineeGeneralSetString(const QSet<QString>& nominees);
+    QString createNomineeToalScoreSetString(const QSet<QString>& nominees);
     QString createNomineeRankListString(const QList<Rank>& ranks);
 
 public:

--- a/lib/include/star/election.h
+++ b/lib/include/star/election.h
@@ -73,7 +73,7 @@ public:
     const Voter& voter() const;
 
     uint score(const QString& nominee) const;
-    QString preference(const QStringList& nominees) const;
+    QString preference(const QSet<QString>& nominees) const;
 };
 
 class Election::Builder

--- a/lib/include/star/electionresult.h
+++ b/lib/include/star/electionresult.h
@@ -14,21 +14,21 @@ class ElectionResult
 //-Instance Variables--------------------------------------------------------------------------------------------------
 private:
     const Election* mElection;
-    QStringList mWinners;
-    QStringList mRunnerUps;
+    QSet<QString> mWinners;
+    QSet<QString> mRunnerUps;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
     ElectionResult();
-    ElectionResult(const Election* election, const QStringList& winners, const QStringList& runnerUps);
+    ElectionResult(const Election* election, const QSet<QString>& winners, const QSet<QString>& runnerUps);
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     bool isNull() const;
 
     const Election* election() const;
-    const QStringList& winners() const;
-    const QStringList& runnerUps() const;
+    const QSet<QString>& winners() const;
+    const QSet<QString>& runnerUps() const;
 };
 
 }

--- a/lib/include/star/expectedelectionresult.h
+++ b/lib/include/star/expectedelectionresult.h
@@ -14,23 +14,23 @@ class ExpectedElectionResult
 {
 //-Instance Variables--------------------------------------------------------------------------------------------------
 private:
-    QStringList mWinners;
-    QStringList mRunnerUps;
+    QSet<QString> mWinners;
+    QSet<QString> mRunnerUps;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
     ExpectedElectionResult();
-    ExpectedElectionResult(const QStringList& winners, const QStringList& runnerUps);
+    ExpectedElectionResult(const QSet<QString>& winners, const QSet<QString>& runnerUps);
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     bool isNull() const;
 
-    const QStringList& winners() const;
-    const QStringList& runnerUps() const;
+    const QSet<QString>& winners() const;
+    const QSet<QString>& runnerUps() const;
 
-    void setWinners(const QStringList& winners);
-    void setRunnerUps(const QStringList& runnerUps);
+    void setWinners(const QSet<QString>& winners);
+    void setRunnerUps(const QSet<QString>& runnerUps);
 
     bool operator==(const ElectionResult& result) const;
 };

--- a/lib/include/star/rank.h
+++ b/lib/include/star/rank.h
@@ -2,12 +2,12 @@
 #define RANK_H
 
 // Qt Includes
-#include <QStringList>
+#include <QSet>
 
 struct Rank
 {
     uint value;
-    QStringList nominees;
+    QSet<QString> nominees;
 
     static QList<Rank> rankSort(const QMap<QString, uint>& valueMap);
 };

--- a/lib/src/election.cpp
+++ b/lib/src/election.cpp
@@ -45,7 +45,7 @@ Election::Ballot::Ballot() {}
 const Election::Voter& Election::Ballot::voter() const { return mVoter; }
 uint Election::Ballot::score(const QString& nominee) const { return mVotes.value(nominee, 0); }
 
-QString Election::Ballot::preference(const QStringList& nominees) const
+QString Election::Ballot::preference(const QSet<QString>& nominees) const
 {
     QString pref;
     uint prefScore = 0;

--- a/lib/src/electionresult.cpp
+++ b/lib/src/electionresult.cpp
@@ -16,7 +16,7 @@ ElectionResult::ElectionResult() :
     mRunnerUps()
 {}
 
-ElectionResult::ElectionResult(const Election* election, const QStringList& winners, const QStringList& runnerUps) :
+ElectionResult::ElectionResult(const Election* election, const QSet<QString>& winners, const QSet<QString>& runnerUps) :
     mElection(election),
     mWinners(winners),
     mRunnerUps(runnerUps)
@@ -27,8 +27,8 @@ ElectionResult::ElectionResult(const Election* election, const QStringList& winn
 bool ElectionResult::isNull() const { return !mElection || mWinners.isEmpty(); }
 
 const Election* ElectionResult::election() const { return mElection; }
-const QStringList& ElectionResult::winners() const { return mWinners; }
-const QStringList& ElectionResult::runnerUps() const { return mRunnerUps; }
+const QSet<QString>& ElectionResult::winners() const { return mWinners; }
+const QSet<QString>& ElectionResult::runnerUps() const { return mRunnerUps; }
 
 
 

--- a/lib/src/expectedelectionresult.cpp
+++ b/lib/src/expectedelectionresult.cpp
@@ -15,7 +15,7 @@ ExpectedElectionResult::ExpectedElectionResult() :
     mRunnerUps()
 {}
 
-ExpectedElectionResult::ExpectedElectionResult(const QStringList& winners, const QStringList& runnerUps) :
+ExpectedElectionResult::ExpectedElectionResult(const QSet<QString>& winners, const QSet<QString>& runnerUps) :
     mWinners(winners),
     mRunnerUps(runnerUps)
 {}
@@ -24,8 +24,8 @@ ExpectedElectionResult::ExpectedElectionResult(const QStringList& winners, const
 //Public:
 bool ExpectedElectionResult::isNull() const { return mWinners.isEmpty(); }
 
-const QStringList& ExpectedElectionResult::winners() const { return mWinners; }
-const QStringList& ExpectedElectionResult::runnerUps() const { return mRunnerUps; }
+const QSet<QString>& ExpectedElectionResult::winners() const { return mWinners; }
+const QSet<QString>& ExpectedElectionResult::runnerUps() const { return mRunnerUps; }
 
 bool ExpectedElectionResult::operator==(const ElectionResult& result) const
 {

--- a/lib/src/rank.cpp
+++ b/lib/src/rank.cpp
@@ -45,7 +45,7 @@ QList<Rank> Rank::rankSort(const QMap<QString, uint>& valueMap)
         }
 
         // Add nominee to rank
-        currentRank.nominees.append(nominee.toString());
+        currentRank.nominees.insert(nominee.toString());
     }
 
     // Finish last rank (necessary since the loop stops before doing this since it uses look-behind)

--- a/lib/src/reference/resultset_p.cpp
+++ b/lib/src/reference/resultset_p.cpp
@@ -74,8 +74,12 @@ Qx::GenericError ResultSetReader::readInto()
         if((convError = Qx::Json::checkedArrayConversion(runnerUps, jRunnerUpArray)).isValid())
             return convError;
 
+        // Convert to sets
+        QSet<QString> winnerSet = QSet<QString>(winners.constBegin(), winners.constEnd());
+        QSet<QString> runnerUpSet = QSet<QString>(runnerUps.constBegin(), runnerUps.constEnd());
+
         // Add expected result to list
-        mTargetList->append(ExpectedElectionResult(winners, runnerUps));
+        mTargetList->append(ExpectedElectionResult(winnerSet, runnerUpSet));
     }
 
     return Qx::GenericError();

--- a/tests/_common/CMakeLists.txt
+++ b/tests/_common/CMakeLists.txt
@@ -18,4 +18,5 @@ target_include_directories(${target_name}
 target_link_libraries(${target_name}
     INTERFACE
         StarCalc::Base
+        Qx::Core
 )

--- a/tests/_common/include/star_test_common.h
+++ b/tests/_common/include/star_test_common.h
@@ -1,5 +1,8 @@
 #include <star/election.h>
-#include <star/reference.h>
+#include <star/electionresult.h>
+#include <star/expectedelectionresult.h>
+
+#include <qx/core/qx-string.h>
 
 // Macros
 #define C_STR(q_str) q_str.toStdString().c_str()
@@ -10,13 +13,13 @@ namespace Star
 
 char* toString(const ExpectedElectionResult& eer)
 {
-    QString string = "W = {" + eer.winners().join(", ") +  "}  | R = {" + eer.runnerUps().join(", ") + '}';
+    QString string = "W = {" + Qx::String::join(eer.winners(), ", ") +  "}  | R = {" + Qx::String::join(eer.runnerUps(), ", ") + '}';
     return qstrdup(string.toUtf8().constData());
 }
 
 char* toString(const ElectionResult& er)
 {
-    QString string = "W = {" + er.winners().join(", ") +  "}  | R = {" + er.runnerUps().join(", ") + '}';
+    QString string = "W = {" + Qx::String::join(er.winners(), ", ") +  "}  | R = {" + Qx::String::join(er.runnerUps(), ", ") + '}';
     return qstrdup(string.toUtf8().constData());
 }
 


### PR DESCRIPTION
This is generally more proper, highlights potential bugs, and prevents unintended failures of ExpectedElectionResult::operator==() when the order of multi-winner/runner-up comparisons differs from the compared ElectionResult.