### PR TITLE
Implement complete Condorcet extra tiebreak (and its component methods), re-label head-to-head wins standalone method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ The original motivation for this project was to facilitate automated election re
  - Determination of election winner, as well as runner-up
  - Ability to select a final tiebreak method:
 	 - None
-	 - FiveStar
-	 - Condorcet
+	 - Five-Star
+	 - Head-to-Head Wins
+	 - Head-to-Head Preference Count
+	 - Head-to-Head Preference Margin
+	 - Random
+	 - Condorcet (combines the previous three methods sequentially)
   - Optional Qt signal connection that details calculation steps
 
 ## Library

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -16,7 +16,7 @@ class Calculator : public QObject
     Q_OBJECT
 //-Class Enums------------------------------------------------------------------------------------------------------
 public:
-    enum ExtendedTiebreakMethod { FiveStar, HTHWins, HTHCount, HTHMargin };
+    enum ExtendedTiebreakMethod { FiveStar, HTHWins, HTHCount, HTHMargin, Random };
 
 //-Class Structs----------------------------------------------------------------------------------------------------
 private:
@@ -155,6 +155,7 @@ private:
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadWins(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadPrefCount(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadMargin(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieRandom(const QSet<QString>& nominees);
 
     // Logging
     QString createNomineeGeneralSetString(const QSet<QString>& nominees);

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -18,10 +18,17 @@ class Calculator : public QObject
 public:
     enum ExtendedTiebreakMethod { FiveStar, HTHWins };
 
+//-Class Structs----------------------------------------------------------------------------------------------------
+private:
+    struct HeadToHeadMaps
+    {
+        QMap<QString, int> wins;
+        QMap<QString, int> prefCounts;
+        QMap<QString, int> margins;
+    };
+
 //-Class Variables------------------------------------------------------------------------------------------------------
 private:
-
-
     // Logging - Intro
     static inline const QString LOG_EVENT_INVALID_ELECTION = QStringLiteral("The provided election is invalid.");
     static inline const QString LOG_EVENT_CALC_START = QStringLiteral("Calculating results of election - %1");
@@ -73,12 +80,14 @@ private:
     static inline const QString LOG_EVENT_RANK_BY_VOTES_OF_MAX_SCORE = QStringLiteral("Ranking relevant nominees by votes of max score...");
     static inline const QString LOG_EVENT_RANKINGS_VOTES_OF_MAX_SCORE = QStringLiteral("Votes of Max Score Rankings:");
 
+    // Logging - Head-to-head
+    static inline const QString LOG_EVENT_CREATE_HEAD_TO_HEAD_MAPS = QStringLiteral("Creating head-to-head maps for relevant nominees...");
+    static inline const QString LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF = QStringLiteral("Using preference ranking to determine facilitate head-to-head of %1 vs %2.");
+    static inline const QString LOG_EVENT_LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF_TIE = QStringLiteral("The head-to-head resulted in a tie (%1).");
+    static inline const QString LOG_EVENT_LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF_WIN = QStringLiteral("The head-to-head resulted in: %1 (%2) > %3 (%4)");
+
     // Logging - Head-to-head wins
     static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS = QStringLiteral("Ranking relevant nominees by head-to-head wins...");
-    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS_PREF = QStringLiteral("Using preference ranking to determine winner of %1 vs %2.");
-    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS_PREF_WINNER = QStringLiteral("%1 won the head-to-head.");
-    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS_PREF_WINNER_IRREL = QStringLiteral("%1 won the head-to-head, but they are not under consideration.");
-    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS_PREF_TIE = QStringLiteral("The head to head resulted in a tie, no win assigned to either participant.");
     static inline const QString LOG_EVENT_RANKINGS_HEAD_TO_HEAD_WINS = QStringLiteral("Head-to-head wins Rankings:");
 
     // Logging - Tiebreak
@@ -108,6 +117,7 @@ private:
 private:
     std::optional<ExtendedTiebreakMethod> mExtraTiebreakMethod;
     const Election* mElection;
+    HeadToHeadMaps mHeadToHeadMaps;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
@@ -121,6 +131,8 @@ private:
     QPair<QSet<QString>, QSet<QString>> performExtendedTiebreak(QSet<QString> initialWinners, QSet<QString> initialRunnerUps, ExtendedTiebreakMethod method);
 
     // Utility
+    HeadToHeadMaps createHeadToHeadMaps(const QSet<QString>& nominees);
+
     QList<Rank> rankByPreference(const QSet<QString>& nominees);
     QList<Rank> rankByScore(const QSet<QString>& nominees);
     QList<Rank> rankByVotesOfMaxScore(const QSet<QString>& nominees);

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -16,7 +16,7 @@ class Calculator : public QObject
     Q_OBJECT
 //-Class Enums------------------------------------------------------------------------------------------------------
 public:
-    enum ExtendedTiebreakMethod { FiveStar, Condorcet };
+    enum ExtendedTiebreakMethod { FiveStar, HTHWins };
 
 //-Class Variables------------------------------------------------------------------------------------------------------
 private:
@@ -130,7 +130,7 @@ private:
     QPair<QSet<QString>, QSet<QString>> breakScoreTie(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakPreferenceTie(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieFiveStar(const QSet<QString>& nominees);
-    QPair<QSet<QString>, QSet<QString>> breakExtendedTieCondorcet(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadWins(const QSet<QString>& nominees);
 
     // Logging
     QString createNomineeGeneralSetString(const QSet<QString>& nominees);

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -16,7 +16,7 @@ class Calculator : public QObject
     Q_OBJECT
 //-Class Enums------------------------------------------------------------------------------------------------------
 public:
-    enum ExtendedTiebreakMethod { FiveStar, HTHWins };
+    enum ExtendedTiebreakMethod { FiveStar, HTHWins, HTHCount, HTHMargin };
 
 //-Class Structs----------------------------------------------------------------------------------------------------
 private:
@@ -70,25 +70,33 @@ private:
     static inline const QString LOG_EVENT_RANK_BY_PREF = QStringLiteral("Ranking relevant nominees by preference...");
     static inline const QString LOG_EVENT_RANK_BY_PREF_HAS_PREF = QStringLiteral(R"(%1 prefers "%2" (Total - %3).)");
     static inline const QString LOG_EVENT_RANK_BY_PREF_NO_PREF = QStringLiteral(R"(%1 has no preference.)");
-    static inline const QString LOG_EVENT_RANKINGS_PREF = QStringLiteral("Preference Rankings:");
+    static inline const QString LOG_EVENT_RANKINGS_PREF = QStringLiteral("Preference rankings:");
 
     // Logging - Score
     static inline const QString LOG_EVENT_RANK_BY_SCORE = QStringLiteral("Ranking relevant nominees by score...");
-    static inline const QString LOG_EVENT_RANKINGS_SCORE = QStringLiteral("Score Rankings:");
+    static inline const QString LOG_EVENT_RANKINGS_SCORE = QStringLiteral("Score rankings:");
 
     // Logging - Max Score Votes
     static inline const QString LOG_EVENT_RANK_BY_VOTES_OF_MAX_SCORE = QStringLiteral("Ranking relevant nominees by votes of max score...");
-    static inline const QString LOG_EVENT_RANKINGS_VOTES_OF_MAX_SCORE = QStringLiteral("Votes of Max Score Rankings:");
+    static inline const QString LOG_EVENT_RANKINGS_VOTES_OF_MAX_SCORE = QStringLiteral("Votes of Max Score rankings:");
 
     // Logging - Head-to-head
-    static inline const QString LOG_EVENT_CREATE_HEAD_TO_HEAD_MAPS = QStringLiteral("Creating head-to-head maps for relevant nominees...");
+    static inline const QString LOG_EVENT_CREATE_HEAD_TO_HEAD_MAPS = QStringLiteral("Creating head-to-head maps for remaining nominees...");
     static inline const QString LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF = QStringLiteral("Using preference ranking to determine facilitate head-to-head of %1 vs %2.");
     static inline const QString LOG_EVENT_LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF_TIE = QStringLiteral("The head-to-head resulted in a tie (%1).");
     static inline const QString LOG_EVENT_LOG_EVENT_CREATE_HEAD_TO_HEAD_PREF_WIN = QStringLiteral("The head-to-head resulted in: %1 (%2) > %3 (%4)");
 
     // Logging - Head-to-head wins
     static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS = QStringLiteral("Ranking relevant nominees by head-to-head wins...");
-    static inline const QString LOG_EVENT_RANKINGS_HEAD_TO_HEAD_WINS = QStringLiteral("Head-to-head wins Rankings:");
+    static inline const QString LOG_EVENT_RANKINGS_HEAD_TO_HEAD_WINS = QStringLiteral("Head-to-head wins rankings:");
+
+    // Logging - Head-to-head pref count
+    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_PREF_COUNT = QStringLiteral("Ranking relevant nominees by head-to-head preference count...");
+    static inline const QString LOG_EVENT_RANKINGS_HEAD_TO_HEAD_PREF_COUNT = QStringLiteral("Head-to-head preference count rankings:");
+
+    // Logging - Head-to-head margin
+    static inline const QString LOG_EVENT_RANK_BY_HEAD_TO_HEAD_MARGIN = QStringLiteral("Ranking relevant nominees by head-to-head margin...");
+    static inline const QString LOG_EVENT_RANKINGS_HEAD_TO_HEAD_MARGIN = QStringLiteral("Head-to-head margin rankings:");
 
     // Logging - Tiebreak
     static inline const QString LOG_EVENT_BREAK_SCORE_TIE = QStringLiteral("Breaking %1-way score tie...");
@@ -137,12 +145,16 @@ private:
     QList<Rank> rankByScore(const QSet<QString>& nominees);
     QList<Rank> rankByVotesOfMaxScore(const QSet<QString>& nominees);
     QList<Rank> rankByHeadToHeadWins(const QSet<QString>& nominees);
+    QList<Rank> rankByHeadToHeadPrefCount(const QSet<QString>& nominees);
+    QList<Rank> rankByHeadToHeadMargin(const QSet<QString>& nominees);
 
     QPair<QSet<QString>, QSet<QString>> rankBasedTiebreak(const QList<Rank>& rankings, const QString& note);
     QPair<QSet<QString>, QSet<QString>> breakScoreTie(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakPreferenceTie(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieFiveStar(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadWins(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadPrefCount(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadMargin(const QSet<QString>& nominees);
 
     // Logging
     QString createNomineeGeneralSetString(const QSet<QString>& nominees);

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -16,7 +16,7 @@ class Calculator : public QObject
     Q_OBJECT
 //-Class Enums------------------------------------------------------------------------------------------------------
 public:
-    enum ExtendedTiebreakMethod { FiveStar, HTHWins, HTHCount, HTHMargin, Random };
+    enum ExtendedTiebreakMethod { FiveStar, HTHWins, HTHCount, HTHMargin, Random, Condorcet };
 
 //-Class Structs----------------------------------------------------------------------------------------------------
 private:
@@ -104,6 +104,12 @@ private:
     static inline const QString LOG_EVENT_BREAK_EXTENDED_TIE = QStringLiteral("Breaking %1-way extended tie (%2 method)...");
     static inline const QString LOG_EVENT_BREAK_RESULT = QStringLiteral("Tie Break - First Place { %1 } | Second Place: { %2 }");
 
+    // Logging - Condorcet
+    static inline const QString LOG_EVENT_CONDORCET_START_STAGES = QStringLiteral("Following STAR Condorcet protocol methodology...");
+    static inline const QString LOG_EVENT_CONDORCET_TIE_REMAINS = QStringLiteral("A tie remains, proceeding to next stage...");
+    static inline const QString LOG_EVENT_CONDORCET_TIE_RESOLVED = QStringLiteral("Tie resolved, returning result (%1)...");
+    static inline const QString LOG_EVENT_CONDORCET_TIE_MITIGATION_FAIL = QStringLiteral("Tie was not mitigated, carrying previous runner-up(s) forward, tie-breaking if needed...");
+
     // Logging - Initial Results
     static inline const QString LOG_EVENT_INITIAL_RESULT_WINNERS = QStringLiteral(R"(Initial winners: { %1 })");
     static inline const QString LOG_EVENT_INITIAL_RESULT_RUNNERUPS = QStringLiteral(R"(Initial runner-ups: { %1 })");
@@ -156,6 +162,7 @@ private:
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadPrefCount(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieHeadToHeadMargin(const QSet<QString>& nominees);
     QPair<QSet<QString>, QSet<QString>> breakExtendedTieRandom(const QSet<QString>& nominees);
+    QPair<QSet<QString>, QSet<QString>> breakExtendedCondorcet(const QSet<QString>& nominees);
 
     // Logging
     QString createNomineeGeneralSetString(const QSet<QString>& nominees);

--- a/lib/include/star/election.h
+++ b/lib/include/star/election.h
@@ -25,7 +25,7 @@ public:
 private:
     QString mName;
     QList<Ballot> mBallots;
-    QMap<QString, uint> mTotals;
+    QMap<QString, int> mTotals;
     QList<Rank> mScoreRankings;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
@@ -40,7 +40,7 @@ public:
     QStringList nominees() const;
     const QList<Ballot>& ballots() const;
 
-    uint totalScore(const QString& nominee) const;
+    int totalScore(const QString& nominee) const;
     const QList<Rank>& scoreRankings() const;
 };
 
@@ -53,7 +53,7 @@ struct Election::Voter
 struct Election::Vote
 {
     QString nominee;
-    uint score = 0;
+    int score = 0;
 };
 
 class Election::Ballot
@@ -62,7 +62,7 @@ class Election::Ballot
 //-Instance Variables--------------------------------------------------------------------------------------------------
 private:
     Voter mVoter;
-    QHash<QString, uint> mVotes;
+    QHash<QString, int> mVotes;
 
 //-Constructor--------------------------------------------------------------------------------------------------------
 private:
@@ -72,7 +72,7 @@ private:
 public:
     const Voter& voter() const;
 
-    uint score(const QString& nominee) const;
+    int score(const QString& nominee) const;
     QString preference(const QSet<QString>& nominees) const;
 };
 

--- a/lib/include/star/rank.h
+++ b/lib/include/star/rank.h
@@ -6,10 +6,10 @@
 
 struct Rank
 {
-    uint value;
+    int value;
     QSet<QString> nominees;
 
-    static QList<Rank> rankSort(const QMap<QString, uint>& valueMap);
+    static QList<Rank> rankSort(const QMap<QString, int>& valueMap);
 };
 
 #endif // RANK_H

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -182,8 +182,8 @@ QPair<QSet<QString>, QSet<QString>> Calculator::performExtendedTiebreak(QSet<QSt
         case FiveStar:
             methodFn = [this](QSet<QString> nominees){ return breakExtendedTieFiveStar(nominees); };
             break;
-        case Condorcet:
-            methodFn = [this](QSet<QString> nominees){ return breakExtendedTieCondorcet(nominees); };
+        case HTHWins:
+            methodFn = [this](QSet<QString> nominees){ return breakExtendedTieHeadToHeadWins(nominees); };
             break;
 
         default:
@@ -386,10 +386,10 @@ QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieFiveStar(const Q
     return rankBasedTiebreak(rankByVotesOfMaxScore(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(FiveStar)));
 }
 
-QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieCondorcet(const QSet<QString>& nominees)
+QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieHeadToHeadWins(const QSet<QString>& nominees)
 {
     // Perform a face-off of each nominee and see which one has the most head-to-head wins
-    return rankBasedTiebreak(rankByHeadToHeadWins(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(Condorcet)));
+    return rankBasedTiebreak(rankByHeadToHeadWins(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(HTHWins)));
 }
 
 QString Calculator::createNomineeGeneralSetString(const QSet<QString>& nominees)

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -264,7 +264,7 @@ Calculator::HeadToHeadMaps Calculator::createHeadToHeadMaps(const QSet<QString>&
 
     // Create a full nominees list with the nominees under consideration at the top
     QStringList otherNominees = mElection->nominees();
-    for(const QString n : nominees)
+    for(const QString& n : nominees)
         otherNominees.removeAll(n);
     QStringList faceOffQueue = QList<QString>(nominees.cbegin(), nominees.cend()) + otherNominees;
 

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -189,6 +189,12 @@ QPair<QSet<QString>, QSet<QString>> Calculator::performExtendedTiebreak(QSet<QSt
         case HTHWins:
             methodFn = [this](QSet<QString> nominees){ return breakExtendedTieHeadToHeadWins(nominees); };
             break;
+        case HTHCount:
+            methodFn = [this](QSet<QString> nominees){ return breakExtendedTieHeadToHeadPrefCount(nominees); };
+            break;
+        case HTHMargin:
+            methodFn = [this](QSet<QString> nominees){ return breakExtendedTieHeadToHeadMargin(nominees); };
+            break;
 
         default:
             qFatal("Unhandled extended tiebreak method");
@@ -377,6 +383,7 @@ QList<Rank> Calculator::rankByVotesOfMaxScore(const QSet<QString>& nominees)
     emit calculationDetail(LOG_EVENT_RANKINGS_VOTES_OF_MAX_SCORE + '\n' + createNomineeRankListString(maxVoteRanks));
     return maxVoteRanks;
 }
+
 QList<Rank> Calculator::rankByHeadToHeadWins(const QSet<QString>& nominees)
 {
     // Determine aggregate face-off wins of nominees list
@@ -393,6 +400,42 @@ QList<Rank> Calculator::rankByHeadToHeadWins(const QSet<QString>& nominees)
 
     emit calculationDetail(LOG_EVENT_RANKINGS_HEAD_TO_HEAD_WINS + '\n' + createNomineeRankListString(headToHeadWinsRanks));
     return headToHeadWinsRanks;
+}
+
+QList<Rank> Calculator::rankByHeadToHeadPrefCount(const QSet<QString>& nominees)
+{
+    // Determine aggregate face-off wins of nominees list
+    emit calculationDetail(LOG_EVENT_RANK_BY_HEAD_TO_HEAD_PREF_COUNT);
+
+    // Copy pref counts map, remove all but the specified nominees
+    QMap<QString, int> prefCounts = mHeadToHeadMaps.prefCounts;
+    prefCounts.removeIf([&nominees](QMap<QString, int>::iterator itr){
+        return !nominees.contains(itr.key());
+    });
+
+    // Create scoped & sorted wins list
+    QList<Rank> headToHeadPrefCountRanks = Rank::rankSort(prefCounts);
+
+    emit calculationDetail(LOG_EVENT_RANKINGS_HEAD_TO_HEAD_PREF_COUNT + '\n' + createNomineeRankListString(headToHeadPrefCountRanks));
+    return headToHeadPrefCountRanks;
+}
+
+QList<Rank> Calculator::rankByHeadToHeadMargin(const QSet<QString>& nominees)
+{
+    // Determine aggregate face-off wins of nominees list
+    emit calculationDetail(LOG_EVENT_RANK_BY_HEAD_TO_HEAD_MARGIN);
+
+    // Copy margins map, remove all but the specified nominees
+    QMap<QString, int> margins = mHeadToHeadMaps.margins;
+    margins.removeIf([&nominees](QMap<QString, int>::iterator itr){
+        return !nominees.contains(itr.key());
+    });
+
+    // Create scoped & sorted wins list
+    QList<Rank> headToHeadMarginRanks = Rank::rankSort(margins);
+
+    emit calculationDetail(LOG_EVENT_RANKINGS_HEAD_TO_HEAD_MARGIN + '\n' + createNomineeRankListString(headToHeadMarginRanks));
+    return headToHeadMarginRanks;
 }
 
 QPair<QSet<QString>, QSet<QString>> Calculator::rankBasedTiebreak(const QList<Rank>& rankings, const QString& note)
@@ -427,6 +470,18 @@ QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieHeadToHeadWins(c
 {
     // Perform a face-off of each nominee and see which one has the most head-to-head wins
     return rankBasedTiebreak(rankByHeadToHeadWins(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(HTHWins)));
+}
+
+QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieHeadToHeadPrefCount(const QSet<QString>& nominees)
+{
+    // Perform a face-off of each nominee and see which one has the most head-to-head wins
+    return rankBasedTiebreak(rankByHeadToHeadPrefCount(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(HTHCount)));
+}
+
+QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieHeadToHeadMargin(const QSet<QString>& nominees)
+{
+    // Perform a face-off of each nominee and see which one has the most head-to-head wins
+    return rankBasedTiebreak(rankByHeadToHeadMargin(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(HTHMargin)));
 }
 
 QString Calculator::createNomineeGeneralSetString(const QSet<QString>& nominees)

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -1,6 +1,9 @@
 // Unit Include
 #include "star/calculator.h"
 
+// Qt Includes
+#include <QRandomGenerator>
+
 // Qx Includes
 #include <qx/core/qx-string.h>
 #include <qx/core/qx-algorithm.h>
@@ -194,6 +197,9 @@ QPair<QSet<QString>, QSet<QString>> Calculator::performExtendedTiebreak(QSet<QSt
             break;
         case HTHMargin:
             methodFn = [this](QSet<QString> nominees){ return breakExtendedTieHeadToHeadMargin(nominees); };
+            break;
+        case Random:
+            methodFn = [this](QSet<QString> nominees){ return breakExtendedTieRandom(nominees); };
             break;
 
         default:
@@ -482,6 +488,28 @@ QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieHeadToHeadMargin
 {
     // Perform a face-off of each nominee and see which one has the most head-to-head wins
     return rankBasedTiebreak(rankByHeadToHeadMargin(nominees), LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(HTHMargin)));
+}
+
+QPair<QSet<QString>, QSet<QString>> Calculator::breakExtendedTieRandom(const QSet<QString>& nominees)
+{
+    emit calculationDetail(LOG_EVENT_BREAK_EXTENDED_TIE.arg(nominees.size()).arg(ENUM_NAME(Random)));
+
+    /* Randomly select a winner of the tiebreak
+     *
+     * There is already some level of randomness since the iteration order of a set is undefined, but this is not enough on its own.
+     */
+    QPair<QSet<QString>, QSet<QString>> brokenTie{{}, nominees};
+
+    quint32 selection = QRandomGenerator::global()->bounded(nominees.size());
+
+    auto itr = nominees.constBegin();
+    for(qsizetype i = 0; i < selection; i++)
+        itr ++;
+
+    brokenTie.first.insert(*itr);
+    brokenTie.second.remove(*itr);
+
+    return brokenTie;
 }
 
 QString Calculator::createNomineeGeneralSetString(const QSet<QString>& nominees)

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -36,7 +36,7 @@ QSet<QString> Calculator::determinePreliminaryLeaders()
     QSet<QString> nomineesInFirst = mElection->scoreRankings().front().nominees;
     if(nomineesInFirst.size() > 1) // First place tie
     {
-        uint firstPlaceScore = mElection->scoreRankings().front().value;
+        int firstPlaceScore = mElection->scoreRankings().front().value;
 
         if(nomineesInFirst.size() == 2) // Two-way
         {
@@ -70,7 +70,7 @@ QSet<QString> Calculator::determinePreliminaryLeaders()
         QSet<QString> nomineesInSecond = mElection->scoreRankings().at(1).nominees;
         if(nomineesInSecond.size() > 1) // Second place tie
         {
-            uint secondPlaceScore = mElection->scoreRankings().at(1).value;
+            int secondPlaceScore = mElection->scoreRankings().at(1).value;
 
             QString tieLogStr = LOG_EVENT_PRELIMINARY_SECOND_TIE.arg(nomineesInSecond.size()).arg(secondPlaceScore) + '\n' + createNomineeGeneralSetString(nomineesInSecond);
             emit calculationDetail(tieLogStr);
@@ -110,7 +110,7 @@ QPair<QSet<QString>, QSet<QString>> Calculator::performPrimaryRunoff(const QSet<
     QSet<QString> nomineesInFirst = prefRanks.front().nominees;
     if(nomineesInFirst.size() > 1) // First place tie
     {
-        uint firstPlacePrefCount = prefRanks.front().value;
+        int firstPlacePrefCount = prefRanks.front().value;
         QString tieLogStr = LOG_EVENT_PRIMARY_FIRST_TIE.arg(nomineesInFirst.size()).arg(firstPlacePrefCount) + '\n' + createNomineeGeneralSetString(nomineesInFirst);
         emit calculationDetail(tieLogStr);
 
@@ -146,7 +146,7 @@ QPair<QSet<QString>, QSet<QString>> Calculator::performPrimaryRunoff(const QSet<
         QSet<QString> nomineesInSecond = prefRanks.at(1).nominees;
         if(nomineesInSecond.size() > 1) // Second place tie
         {
-            uint secondPlacePrefCount = prefRanks.at(1).value;
+            int secondPlacePrefCount = prefRanks.at(1).value;
             QString tieLogStr = LOG_EVENT_PRIMARY_SECOND_TIE.arg(nomineesInSecond.size()).arg(secondPlacePrefCount) + '\n' + createNomineeGeneralSetString(nomineesInSecond);
             emit calculationDetail(tieLogStr);
 
@@ -232,7 +232,7 @@ QList<Rank> Calculator::rankByPreference(const QSet<QString>& nominees)
 {
     // Determine aggregate preference of nominee list
     emit calculationDetail(LOG_EVENT_RANK_BY_PREF);
-    QMap<QString, uint> totalPreferenceMap;
+    QMap<QString, int> totalPreferenceMap;
 
     /* Add all nominees with an initial preference count of 0, since some might not be preferred even
      * once, and therefore be missed by the next loop
@@ -246,7 +246,7 @@ QList<Rank> Calculator::rankByPreference(const QSet<QString>& nominees)
         QString pref = ballot.preference(nominees);
         if(!pref.isNull())
         {
-            uint newTotal = ++totalPreferenceMap[pref];
+            int newTotal = ++totalPreferenceMap[pref];
             emit calculationDetail(LOG_EVENT_RANK_BY_PREF_HAS_PREF.arg(voterName, pref).arg(newTotal));
         }
         else
@@ -267,7 +267,7 @@ QList<Rank> Calculator::rankByScore(const QSet<QString>& nominees)
      * the full score rankings that are part of the Election
      */
     emit calculationDetail(LOG_EVENT_RANK_BY_SCORE);
-    QMap<QString, uint> totalScoreMap;
+    QMap<QString, int> totalScoreMap;
 
     for(const QString& nominee : nominees)
         totalScoreMap[nominee] = mElection->totalScore(nominee);
@@ -283,7 +283,7 @@ QList<Rank> Calculator::rankByVotesOfMaxScore(const QSet<QString>& nominees)
 {
     // Determine aggregate max votes of nominee list
     emit calculationDetail(LOG_EVENT_RANK_BY_VOTES_OF_MAX_SCORE);
-    QMap<QString, uint> totalMaxVotesMap;
+    QMap<QString, int> totalMaxVotesMap;
 
     for(const QString& nominee : nominees)
     {
@@ -306,7 +306,7 @@ QList<Rank> Calculator::rankByHeadToHeadWins(const QSet<QString>& nominees)
 {
     // Determine aggregate face-off wins of nominees list
     emit calculationDetail(LOG_EVENT_RANK_BY_HEAD_TO_HEAD_WINS);
-    QMap<QString, uint> headToHeadWinsMap;
+    QMap<QString, int> headToHeadWinsMap;
 
     /* Add all nominees with an initial win count of 0, since some might not win even
      * once, and therefore be missed by the main loop

--- a/lib/src/election.cpp
+++ b/lib/src/election.cpp
@@ -20,9 +20,9 @@ QString Election::name() const { return mName; }
 QStringList Election::nominees() const { return mTotals.keys(); }
 const QList<Election::Ballot>& Election::ballots() const { return mBallots; }
 
-uint Election::totalScore(const QString& nominee) const
+int Election::totalScore(const QString& nominee) const
 {
-    // NOTE: This could instead return a std::optional<uint> for if *nominee* is missing, but that
+    // NOTE: This could instead return a std::optional<int> for if *nominee* is missing, but that
     // would indicate a bug elsewhere and should never happen, so instead this just throws.
     if(!mTotals.contains(nominee))
         throw std::runtime_error(std::string(Q_FUNC_INFO) + " the desired nominee is not present.");
@@ -43,17 +43,17 @@ Election::Ballot::Ballot() {}
 //-Instance Functions-------------------------------------------------------------------------------------------------
 //Public:
 const Election::Voter& Election::Ballot::voter() const { return mVoter; }
-uint Election::Ballot::score(const QString& nominee) const { return mVotes.value(nominee, 0); }
+int Election::Ballot::score(const QString& nominee) const { return mVotes.value(nominee, 0); }
 
 QString Election::Ballot::preference(const QSet<QString>& nominees) const
 {
     QString pref;
-    uint prefScore = 0;
+    int prefScore = 0;
 
     // Check for highest score
     for(const QString& nominee : nominees)
     {
-        uint nomScore = score(nominee);
+        int nomScore = score(nominee);
         if(nomScore == prefScore)
         {
             pref = QString(); // Score ties prevent preference
@@ -92,7 +92,8 @@ Election::Builder& Election::Builder::wBallot(const Voter& voter, const QList<Vo
     for(const Vote& vote : votes)
     {
         const QString& nominee = vote.nominee;
-        uint score = std::min(vote.score, uint(5));
+
+        int score = std::max(0, std::min(vote.score, 5));
         ballot.mVotes[nominee] = score;
         mConstruct.mTotals[nominee] += score;
     }

--- a/lib/src/rank.cpp
+++ b/lib/src/rank.cpp
@@ -10,7 +10,7 @@
 
 //-Struct Functions-------------------------------------------------------------------------------------------------
 //Public:
-QList<Rank> Rank::rankSort(const QMap<QString, uint>& valueMap)
+QList<Rank> Rank::rankSort(const QMap<QString, int>& valueMap)
 {
     QList<Rank> rankings;
 
@@ -18,7 +18,7 @@ QList<Rank> Rank::rankSort(const QMap<QString, uint>& valueMap)
      * key (ascending), this will create a ranking list from lowest rank to highest rank with all
      * nominees at a given rank (> 1 if there are ties) tied to its corresponding score as the key.
      */
-    QMultiMap<uint, QStringView> reverseRankings;
+    QMultiMap<int, QStringView> reverseRankings;
     for(auto [nominee, value] : valueMap.asKeyValueRange())
         reverseRankings.insert(value, nominee);
 
@@ -27,7 +27,7 @@ QList<Rank> Rank::rankSort(const QMap<QString, uint>& valueMap)
      * to iterate by key "group". So, transform the rankings into a more convenient form that
      * uses a list for nominees.
      */
-    uint currentKey = reverseRankings.firstKey();
+    int currentKey = reverseRankings.firstKey();
     Rank currentRank = {.value = currentKey, .nominees = {}};
     for(auto [totalScore, nominee] : reverseRankings.asKeyValueRange())
     {

--- a/lib/src/reference.cpp
+++ b/lib/src/reference.cpp
@@ -29,7 +29,7 @@ namespace
                 const RefBallot& rBallot = box.ballots()[bIdx];
 
                 // Get votes that pertain to category
-                const QList<uint>& categoryVotes = rBallot.votes[cIdx];
+                const QList<int>& categoryVotes = rBallot.votes[cIdx];
 
                 // List to fill with nominee mapped votes in standard form
                 QList<Election::Vote> mappedVotes;

--- a/lib/src/reference/ballotbox_p.cpp
+++ b/lib/src/reference/ballotbox_p.cpp
@@ -104,7 +104,7 @@ Qx::GenericError RefBallotBox::Reader::parseBallot(const QList<QVariant>& ballot
 
     for(const RefCategoryHeader& ch : mCategoryConfig->headers())
     {
-        QList<uint> categoryVotes;
+        QList<int> categoryVotes;
 
         for(uint i = 0; i < ch.nomineeCount; i++, cIdx++)
         {
@@ -119,7 +119,7 @@ Qx::GenericError RefBallotBox::Reader::parseBallot(const QList<QVariant>& ballot
 
             // Get value from field
             bool validValue;
-            uint vote = voteField.toUInt(&validValue);
+            int vote = voteField.toUInt(&validValue); // Stored as int, but should be a uint
 
             if(!validValue || vote > 5)
                 return Qx::GenericError(ERROR_TEMPLATE).setSecondaryInfo(ERR_INVALID_VOTE.arg(ballotNum).arg(cIdx));

--- a/lib/src/reference/ballotbox_p.h
+++ b/lib/src/reference/ballotbox_p.h
@@ -26,7 +26,7 @@ struct RefBallot
 {
     QString voter;
     QDate submissionDate;
-    QList<QList<uint>> votes;
+    QList<QList<int>> votes;
 };
 
 class RefBallotBox
@@ -77,7 +77,7 @@ private:
     RefBallotBox* mTargetBox;
     QFile mCsvFile;
     const RefCategoryConfig* mCategoryConfig;
-    uint mExpectedFieldCount;
+    qsizetype mExpectedFieldCount;
 
 //-Constructor--------------------------------------------------------------------------------------------------------
 public:

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -50,7 +50,7 @@ void tst_ties::all_tie_cases_data()
                           Star::ExpectedElectionResult results,
                           std::optional<Star::Calculator::ExtendedTiebreakMethod> extendedMethod){
 
-        static Star::Election::Builder builder("");
+        Star::Election::Builder builder(testName);
 
         for(QList<Star::Election::Vote> voteList : votes)
             builder.wBallot({}, voteList);
@@ -58,10 +58,11 @@ void tst_ties::all_tie_cases_data()
         Star::Election election = builder.build();
 
         QTest::newRow(C_STR(testName)) << election << results << extendedMethod;
-        builder.reset();
     };
 
     //-Populate test table rows with each case-----------------------------
+
+    //################################### PRELIMINARY ####################################################
 
     addTestRow("Preliminary - First place 2-way tie",
                {
@@ -187,6 +188,8 @@ void tst_ties::all_tie_cases_data()
                Star::ExpectedElectionResult({candidate3}, {candidate1}),
                std::nullopt
     );
+
+    //################################### RUNOFF ####################################################
 
     addTestRow("Runoff - First place N-way tie, successful break",
                {
@@ -434,6 +437,8 @@ void tst_ties::all_tie_cases_data()
                Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
                std::nullopt
     );
+
+    //################################### EXTENDED - FIVESTAR ####################################################
 
     addTestRow("Extended [FiveStar] - First place N-way tie, successful break",
                {
@@ -700,6 +705,8 @@ void tst_ties::all_tie_cases_data()
                Star::Calculator::FiveStar
     );
 
+    //################################### EXTENDED - HEAD-TO-HEAD-WINS ####################################################
+
     addTestRow("Extended [HTHWins] - First place N-way tie, successful break",
                {
                    {
@@ -964,6 +971,281 @@ void tst_ties::all_tie_cases_data()
                Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
                Star::Calculator::HTHWins
     );
+
+    //################################### EXTENDED - HEAD-TO-HEAD PREF COUNT ####################################################
+
+    addTestRow("Extended [HTHCount] - First place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate2}),
+               Star::Calculator::HTHCount
+    );
+
+    addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, no fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3, candidate4}, {}),
+               Star::Calculator::HTHCount
+    );
+
+    addTestRow("Extended [HTHCount] - Second place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3}),
+               Star::Calculator::HTHCount
+    );
+
+    addTestRow("Extended [HTHCount] - Second place N-way tie, unsuccessful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate4, candidate3}),
+               Star::Calculator::HTHCount
+    );
+
+    //################################### EXTENDED - HEAD-TO-HEAD MARGIN ####################################################
+
+    addTestRow("Extended [HTHMargin] - First place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 2},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 0},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate2}),
+               Star::Calculator::HTHMargin
+    );
+
+    addTestRow("Extended [HTHMargin] - First place N-way tie, unsuccessful break, no fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3, candidate4}, {}),
+               Star::Calculator::HTHMargin
+    );
+
+    addTestRow("Extended [HTHMargin] - Second place N-way tie, successful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 3}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate3}),
+               Star::Calculator::HTHMargin
+    );
+
+    addTestRow("Extended [HTHMargin] - Second place N-way tie, unsuccessful break",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 5},
+                       {.nominee = candidate3, .score = 1},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 2}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 2},
+                       {.nominee = candidate3, .score = 4},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate1}, {candidate4, candidate3}),
+               Star::Calculator::HTHMargin
+    );
+
+    //################################### EXTENDED - RANDOM ####################################################
+
+    /* NOTE: A separate test for this would need to be made if the lib could be accessed with fine enough
+     * granularity to check just the result of the tiebreak itself, though that would be really jank. The method
+     * is simple enough and always results in a winner, with all other candidates that were part of the break being
+     * set to runner-up, so it should be ok.
+     *
+     * Otherwise, a separate case within this test target could be made that just ensures that the results
+     * after using the method several times is fairly random (i.e. check for at least 2-3 different results).
+     */
 }
 
 void tst_ties::all_tie_cases()

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -1011,6 +1011,40 @@ void tst_ties::all_tie_cases_data()
                Star::Calculator::HTHCount
     );
 
+    addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, single fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 2},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 4}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 0}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3, candidate4}, {}),
+               Star::Calculator::HTHCount
+    );
+
+    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+
     addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, no fallback for second",
                {
                    {
@@ -1167,6 +1201,40 @@ void tst_ties::all_tie_cases_data()
                Star::ExpectedElectionResult({candidate3, candidate4}, {}),
                Star::Calculator::HTHMargin
     );
+
+    addTestRow("Extended [HTHMargin] - First place N-way tie, unsuccessful break, single fallback for second",
+               {
+                   {
+                       {.nominee = candidate1, .score = 4},
+                       {.nominee = candidate2, .score = 1},
+                       {.nominee = candidate3, .score = 5},
+                       {.nominee = candidate4, .score = 0}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 3},
+                       {.nominee = candidate2, .score = 4},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 1}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 1},
+                       {.nominee = candidate2, .score = 3},
+                       {.nominee = candidate3, .score = 0},
+                       {.nominee = candidate4, .score = 5}
+                   },
+                   {
+                       {.nominee = candidate1, .score = 5},
+                       {.nominee = candidate2, .score = 0},
+                       {.nominee = candidate3, .score = 3},
+                       {.nominee = candidate4, .score = 5}
+                   }
+               },
+               Star::ExpectedElectionResult({candidate3, candidate4}, {candidate1}),
+               Star::Calculator::HTHMargin
+    );
+
+    // TODO: addTestRow("Extended [HTHMargin] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+    // TODO: addTestRow("Extended [HTHMargin] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
 
     addTestRow("Extended [HTHMargin] - Second place N-way tie, successful break",
                {

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -1042,8 +1042,8 @@ void tst_ties::all_tie_cases_data()
                Star::Calculator::HTHCount
     );
 
-     TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
-     TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
 
     addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, no fallback for second",
                {

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -1042,8 +1042,8 @@ void tst_ties::all_tie_cases_data()
                Star::Calculator::HTHCount
     );
 
-    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
-    // TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+     TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+     TODO: addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
 
     addTestRow("Extended [HTHCount] - First place N-way tie, unsuccessful break, no fallback for second",
                {
@@ -1327,6 +1327,7 @@ void tst_ties::all_tie_cases()
     static Star::Calculator calc;
     calc.setElection(&election);
     calc.setExtraTiebreakMethod(extended_method);
+    calc.setSpeculative(false);
 
     // Compare results
     QCOMPARE(calc.calculateResult(), expected_result);

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -1038,7 +1038,7 @@ void tst_ties::all_tie_cases_data()
                        {.nominee = candidate4, .score = 0}
                    }
                },
-               Star::ExpectedElectionResult({candidate3, candidate4}, {}),
+               Star::ExpectedElectionResult({candidate3, candidate4}, {candidate1}),
                Star::Calculator::HTHCount
     );
 

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -700,7 +700,7 @@ void tst_ties::all_tie_cases_data()
                Star::Calculator::FiveStar
     );
 
-    addTestRow("Extended [Condorcet] - First place N-way tie, successful break",
+    addTestRow("Extended [HTHWins] - First place N-way tie, successful break",
                {
                    {
                        {.nominee = candidate1, .score = 5},
@@ -746,10 +746,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate1}, {candidate2}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, single fallback for second",
+    addTestRow("Extended [HTHWins] - First place N-way tie, unsuccessful break, single fallback for second",
                {
                    {
                        {.nominee = candidate1, .score = 5},
@@ -783,10 +783,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
+    addTestRow("Extended [HTHWins] - First place N-way tie, unsuccessful break, tied fallback for second that successfully breaks",
                {
                    {
                        {.nominee = candidate1, .score = 5},
@@ -832,10 +832,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate2, candidate1}, {candidate5}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
+    addTestRow("Extended [HTHWins] - First place N-way tie, unsuccessful break, tied fallback for second that doesn't break",
                {
                    {
                        {.nominee = candidate1, .score = 5},
@@ -881,10 +881,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate2, candidate1}, {candidate3, candidate5}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - First place N-way tie, unsuccessful break, no fallback for second",
+    addTestRow("Extended [HTHWins] - First place N-way tie, unsuccessful break, no fallback for second",
                {
                    {
                        {.nominee = candidate1, .score = 5},
@@ -906,10 +906,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate2, candidate3, candidate1}, {}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - Second place N-way tie, successful break",
+    addTestRow("Extended [HTHWins] - Second place N-way tie, successful break",
                {
                    {
                        {.nominee = candidate1, .score = 1},
@@ -931,10 +931,10 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate3}, {candidate1}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 
-    addTestRow("Extended [Condorcet] - Second place N-way tie, unsuccessful break",
+    addTestRow("Extended [HTHWins] - Second place N-way tie, unsuccessful break",
                {
                    {
                        {.nominee = candidate1, .score = 4},
@@ -962,7 +962,7 @@ void tst_ties::all_tie_cases_data()
                    }
                },
                Star::ExpectedElectionResult({candidate1}, {candidate3, candidate4}),
-               Star::Calculator::Condorcet
+               Star::Calculator::HTHWins
     );
 }
 


### PR DESCRIPTION
The previous "Condorcet" method was actually just Head-to-Head wins.

This adds a proper full Condorcet method extra tiebreaker, as well as the individual component methods that it is composed of, renaming the previous one to just Head-to-Head wins.