### PR TITLE
Merge prelim. candidate determination and prelim. tie reduction, track runoff assignment details, add runoff simulation for defacto winner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060000)
 
 # Fetch Qx (build and import from source)
 include(OB/FetchQx)
-fetch_qx("3de0116d75f94dcc14ab5c9c0bcfa3c1854aba09")
+fetch_qx("285b863ec9739d6eb7c803d9b6554d71afed75ee")
 
 # Fetch Neargye's Magic Enum
 include(OB/FetchMagicEnum)

--- a/app/src/core.cpp
+++ b/app/src/core.cpp
@@ -100,8 +100,8 @@ ErrorCode Core::initialize()
     // Parse
     if(!clParser.parse(mArguments))
     {
+        postError(NAME, Qx::GenericError(Qx::GenericError::Error, LOG_ERR_INVALID_ARGS, clParser.errorText()));
         showHelp();
-        logError(NAME, Qx::GenericError(Qx::GenericError::Error, LOG_ERR_INVALID_ARGS, clParser.errorText()));
         return ErrorCode::INVALID_ARGS;
     }
 

--- a/app/src/core.h
+++ b/app/src/core.h
@@ -33,6 +33,7 @@ private:
 
     // Logging - Errors
     static inline const QString LOG_ERR_INVALID_ARGS = QStringLiteral("Invalid arguments provided.");
+    static inline const QString LOG_ERR_INVALID_CALC_OPTION = QStringLiteral("Invalid calculator option provided.");
 
     // Logging - Messages
     static inline const QString LOG_EVENT_INIT = QStringLiteral("Initializing " PROJECT_SHORT_NAME "...");
@@ -61,13 +62,26 @@ private:
     static inline const QString CL_OPT_BOX_L_NAME = QStringLiteral("box");
     static inline const QString CL_OPT_BOX_DESC = QStringLiteral("Specifies the path to the ballot box CSV file.");
 
-    static inline const QString CL_OPT_TRUE_TIES_S_NAME = QStringLiteral("t");
-    static inline const QString CL_OPT_TRUE_TIES_L_NAME = QStringLiteral("true-ties");
-    static inline const QString CL_OPT_TRUE_TIES_DESC = QStringLiteral("Ends an election prematurely instead of using a random tiebreaker when an unresovable tie occurs.");
-
-    static inline const QString CL_OPT_EXTRA_TIEBREAK_S_NAME = QStringLiteral("e");
-    static inline const QString CL_OPT_EXTRA_TIEBREAK_L_NAME = QStringLiteral("extra-tiebreak");
-    static inline const QString CL_OPT_EXTRA_TIEBREAK_DESC = QStringLiteral("Uses the Condorcet protocol tiebreaker during the scoring round before the random tiebreaker if necessary.");
+    static inline const QString CL_OPT_CALC_OPTIONS_S_NAME = QStringLiteral("o");
+    static inline const QString CL_OPT_CALC_OPTIONS_L_NAME = QStringLiteral("calc-options");
+    static inline const QString CL_OPT_CALC_OPTIONS_DESC = QStringLiteral(
+        "Comma separated list of calculator options:\n"
+        "\n"
+        ">AllowTrueTies - Ends an election prematurely instead of using a random tiebreaker when an unresolvable tie occurs\n"
+        ">CondorcetProtocol - Uses the protocol during the scoring round before the random tiebreaker if necessary\n"
+        ">DefactoWinner - If true ties are enabled and an unresolvable tie occurs for second seed in the qualifier, gives the win to the first seed if they would defeat all of them in the runoff\n"
+    );
+    /* NOTE: This will cause a compilation error when changing Star::Calculator::Options in order to prompt the developer
+     * to ensure any new options have been described above and then manually check them off here
+     */
+    static_assert(magic_enum::enum_values<Star::Calculator::Option>() == std::array<Star::Calculator::Option, 4>{
+            Star::Calculator::NoOptions,
+            Star::Calculator::AllowTrueTies,
+            Star::Calculator::CondorcetProtocol,
+            Star::Calculator::DefactoWinner
+        },
+        "Missing description for a calculator option"
+    );
 
     static inline const QString CL_OPT_MINIMAL_S_NAME = QStringLiteral("m");
     static inline const QString CL_OPT_MINIMAL_L_NAME = QStringLiteral("minimal");
@@ -78,12 +92,11 @@ private:
     static inline const QCommandLineOption CL_OPTION_VERSION{{CL_OPT_VERSION_S_NAME, CL_OPT_VERSION_L_NAME}, CL_OPT_VERSION_DESC}; // Boolean option
     static inline const QCommandLineOption CL_OPTION_CONFIG{{CL_OPT_CONFIG_S_NAME, CL_OPT_CONFIG_L_NAME}, CL_OPT_CONFIG_DESC, "config"}; // Takes value
     static inline const QCommandLineOption CL_OPTION_BOX{{CL_OPT_BOX_S_NAME, CL_OPT_BOX_L_NAME}, CL_OPT_BOX_DESC, "box"}; // Takes value
-    static inline const QCommandLineOption CL_OPTION_TRUE_TIES{{CL_OPT_TRUE_TIES_S_NAME, CL_OPT_TRUE_TIES_L_NAME}, CL_OPT_TRUE_TIES_DESC}; // Boolean option
-    static inline const QCommandLineOption CL_OPTION_EXTRA_TIEBREAK{{CL_OPT_EXTRA_TIEBREAK_S_NAME, CL_OPT_EXTRA_TIEBREAK_L_NAME}, CL_OPT_EXTRA_TIEBREAK_DESC}; // Boolean option
+    static inline const QCommandLineOption CL_OPTION_CALC_OPTIONS{{CL_OPT_CALC_OPTIONS_S_NAME, CL_OPT_CALC_OPTIONS_L_NAME}, CL_OPT_CALC_OPTIONS_DESC, "calc-options"}; // Takes value
     static inline const QCommandLineOption CL_OPTION_MINIMAL{{CL_OPT_MINIMAL_S_NAME, CL_OPT_MINIMAL_L_NAME}, CL_OPT_MINIMAL_DESC}; // Boolean option
 
     static inline const QList<const QCommandLineOption*> CL_OPTIONS_ALL{&CL_OPTION_HELP, &CL_OPTION_VERSION, &CL_OPTION_CONFIG, &CL_OPTION_BOX,
-                                                                        &CL_OPTION_MINIMAL, &CL_OPTION_TRUE_TIES, &CL_OPTION_EXTRA_TIEBREAK};
+                                                                        &CL_OPTION_MINIMAL, &CL_OPTION_CALC_OPTIONS};
 
     // Help template
     static inline const QString HELP_TEMPL = "Usage:\n"

--- a/app/src/errorcode.h
+++ b/app/src/errorcode.h
@@ -5,6 +5,7 @@ enum ErrorCode{
     // Common
     NO_ERR = 0,
     INVALID_ARGS = 1,
+    INVALID_CALC_OPT = 2,
 
     // Reference
     INVALID_REF_ELECTION = 100

--- a/app/src/resultspresenter.cpp
+++ b/app/src/resultspresenter.cpp
@@ -112,7 +112,7 @@ void ResultPresenter::printSummary()
     };
 
     // Add results    
-    for(int res = 0, row = 1; res < mResults->size(); res++, row++)
+    for(qsizetype res = 0, row = 1; res < mResults->size(); res++, row++)
     {
         // Result
         const Star::ElectionResult& result = mResults->at(res);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -42,6 +42,7 @@ set(CXX_PUBLIC_HEADERS
     election.h
     electionresult.h
     expectedelectionresult.h
+    qualifierresult.h
     rank.h
     reference.h
 )
@@ -59,6 +60,7 @@ set(CXX_IMPLEMENTATION
     electionresult.cpp
     expectedelectionresult.cpp
     headtoheadresults.cpp
+    qualifierresult.cpp
     rank.cpp
     reference.cpp
     reference/ballotbox_p.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,6 +45,7 @@ set(CXX_PUBLIC_HEADERS
     qualifierresult.h
     rank.h
     reference.h
+    seat.h
 )
 
 set(CXX_PRIVATE_HEADERS
@@ -66,6 +67,7 @@ set(CXX_IMPLEMENTATION
     reference/ballotbox_p.cpp
     reference/categoryconfig_p.cpp
     reference/resultset_p.cpp
+    seat.cpp
 )
 
 # Build pathed implementation file list

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -141,8 +141,8 @@ public:
 //-Instance Functions-------------------------------------------------------------------------------------------------
 private:
     // Main steps
-    QString performPrimaryRunoff(QPair<QString, QString> candidates) const;
     QualifierResult performRunoffQualifier(const QList<Rank>& scoreRankings) const;
+    QString performPrimaryRunoff(QPair<QString, QString> candidates) const;
 
     // Utility
     QList<Rank> rankByScore(const QSet<QString>& candidates, Rank::Order order) const;

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -38,6 +38,21 @@ private:
     static inline const QString LOG_EVENT_INITAL_RAW_RANKINGS = QStringLiteral("Initial score rankings:");
     static inline const QString LOG_EVENT_CALC_HEAD_TO_HEAD = QStringLiteral("Pre-calculating head-to-head matchup results...");
 
+    // Logging - Perform Runoff Qualifier
+    static inline const QString LOG_EVENT_QUALIFIER = QStringLiteral("Performing runoff qualifier to seed candidates for the runoff.");
+    static inline const QString LOG_EVENT_QUALIFIER_TOP = QStringLiteral("Trying to determine remaining %1 candidate(s) to advance between:");
+    static inline const QString LOG_EVENT_QUALIFIER_ADVANCE_CANDIDATES = QStringLiteral("Advancing candidate(s):");
+    static inline const QString LOG_EVENT_QUALIFIER_CUT_CANDIDATES = QStringLiteral("Cutting candidate(s):");
+    static inline const QString LOG_EVENT_QUALIFIER_NO_RANDOM = QStringLiteral("Random tiebreaker is disabled.");
+    static inline const QString LOG_EVENT_QUALIFIER_UNSUCCESSFUL = QStringLiteral("Unable to resolve scoring round tie to reach the target number of candidates.");
+    static inline const QString LOG_EVENT_QUALIFIER_RESULT = QStringLiteral(
+        "Qualifier Result:\n"
+        "First Seed: %1\n"
+        "Second Seed: %2\n"
+        "Simultaneous: %3\n"
+        "Overflow: {%4}\n"
+    );
+
     // Logging - Determine Scoring round Leaders
     static inline const QString LOG_EVENT_DETERMINE_SCORING_ROUND_LEADERS = QStringLiteral("Determining scoring round score leaders...");
     static inline const QString LOG_EVENT_SCORING_ROUND_FIRST_TIE_BENIGN = QStringLiteral("There is a benign 2-way tie for scoring round first place <%1>:");
@@ -46,15 +61,6 @@ private:
     static inline const QString LOG_EVENT_SCORING_ROUND_SECOND_TIE = QStringLiteral("There is a %1-way tie for scoring round second place <%2>:");
     static inline const QString LOG_EVENT_SCORING_ROUND_SECOND_NO_TIE = QStringLiteral(R"(Scoring round second place is uncontested: "%1")");
     static inline const QString LOG_EVENT_SCORING_ROUND_LEADERS = QStringLiteral("Scoring round leaders are:");
-
-    // Logging - Scoring round Candidate Tie Reduction
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_REDUCTION = QStringLiteral("Resolving %1-way tie down to the target of %2 candidates...");
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_REDUCTION_TOP = QStringLiteral("Trying to determine remaining %1 candidate(s) to advance between:");
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_CUT_CANDIDATES = QStringLiteral("Cutting candidate(s):");
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_ADVANCE_CANDIDATES = QStringLiteral("Advancing candidate(s):");
-    static inline const QString LOG_EVENT_SCORING_ROUND_NO_RANDOM = QStringLiteral("Random tiebreaker is disabled.");
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_REDUCTION_UNSUCCESSFUL = QStringLiteral(R"(Unable to resolve scoring round tie to reach the target number of candidates.)");
-    static inline const QString LOG_EVENT_SCORING_ROUND_TIE_REDUCTION_RESULT = QStringLiteral("Scoring round tie reduced to:");
 
     // Logging - Main Runoff
     static inline const QString LOG_EVENT_RUNOFF_CANDIDATES = QStringLiteral(R"("%1" & "%2" advance to the runoff.)");
@@ -66,7 +72,7 @@ private:
     static inline const QString LOG_EVENT_RUNOFF_CHOOSING_RANDOM_WINNER = QStringLiteral("Choosing runoff winner randomly.");
     static inline const QString LOG_EVENT_RUNOFF_NO_RANDOM = QStringLiteral("Random tiebreaker is disabled, the runoff candidates remained tied.");
     static inline const QString LOG_EVENT_RUNOFF_WINNER = QStringLiteral(R"(The runoff resulted in a win for: "%1")");
-    static inline const QString LOG_EVENT_RUNOFF_UNRESOLVED = QStringLiteral(R"(The runoff tie could not be broken.)");
+    static inline const QString LOG_EVENT_RUNOFF_UNRESOLVED = QStringLiteral("The runoff tie could not be broken.");
 
     // Logging - Ranking
     static inline const QString LOG_EVENT_RANK_BY_SCORE = QStringLiteral("Ranking relevant candidates by score (%1)...");
@@ -92,15 +98,17 @@ private:
     static inline const QString LOG_EVENT_NO_RUNOFF = QStringLiteral("The number of candidates could not be narrowed to two in order to perform the runoff.");
 
     // Logging - Final Results
-    static inline const QString LOG_EVENT_FINAL_RESULTS = QStringLiteral("Final Results:\n"
-                                                                         "\n"
-                                                                         "Filled Seats:\n"
-                                                                         "%1"
-                                                                         "\n"
-                                                                         "Unresolved Candidates:\n"
-                                                                         "%2"
-                                                                         "\n"
-                                                                         "Unfilled Seats: %3\n");
+    static inline const QString LOG_EVENT_FINAL_RESULTS = QStringLiteral(
+        "Final Results:\n"
+        "\n"
+        "Filled Seats:\n"
+        "%1"
+        "\n"
+        "Unresolved Candidates:\n"
+        "%2"
+        "\n"
+        "Unfilled Seats: %3\n"
+    );
 
     // Logging - Finish
     static inline const QString LOG_EVENT_CALC_FINISH = QStringLiteral("Calculation complete.");
@@ -152,6 +160,7 @@ private:
     QString createCandidateGeneralSetString(const QSet<QString>& candidates) const;
     QString createCandidateToalScoreSetString(const QSet<QString>& candidates) const;
     QString createCandidateRankListString(const QList<Rank>& ranks) const;
+    void logQualifierResult(const QualifierResult& result) const;
     void logElectionResults(const ElectionResult& results) const;
 
 public:

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -8,6 +8,7 @@
 // Project Includes
 #include "star/election.h"
 #include "star/electionresult.h"
+#include "star/qualifierresult.h"
 
 namespace Star
 {
@@ -132,9 +133,8 @@ public:
 //-Instance Functions-------------------------------------------------------------------------------------------------
 private:
     // Main steps
-    QSet<QString> determineScoringRoundLeaders(const QList<Rank>& scoreRankings);
     QString performPrimaryRunoff(QPair<QString, QString> candidates) const;
-    QSet<QString> scoringRoundTieReduction(const QSet<QString>& candidates, qsizetype desiredCount) const;
+    QualifierResult performRunoffQualifier(const QList<Rank>& scoreRankings) const;
 
     // Utility
     QList<Rank> rankByScore(const QSet<QString>& candidates, Rank::Order order) const;

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -53,15 +53,6 @@ private:
         "Overflow: {%4}\n"
     );
 
-    // Logging - Determine Scoring round Leaders
-    static inline const QString LOG_EVENT_DETERMINE_SCORING_ROUND_LEADERS = QStringLiteral("Determining scoring round score leaders...");
-    static inline const QString LOG_EVENT_SCORING_ROUND_FIRST_TIE_BENIGN = QStringLiteral("There is a benign 2-way tie for scoring round first place <%1>:");
-    static inline const QString LOG_EVENT_SCORING_ROUND_FIRST_TIE = QStringLiteral("There is a %1-way tie for scoring round first place <%2>:");
-    static inline const QString LOG_EVENT_SCORING_ROUND_FIRST_NO_TIE = QStringLiteral(R"(Scoring round first place is uncontested: "%1")");
-    static inline const QString LOG_EVENT_SCORING_ROUND_SECOND_TIE = QStringLiteral("There is a %1-way tie for scoring round second place <%2>:");
-    static inline const QString LOG_EVENT_SCORING_ROUND_SECOND_NO_TIE = QStringLiteral(R"(Scoring round second place is uncontested: "%1")");
-    static inline const QString LOG_EVENT_SCORING_ROUND_LEADERS = QStringLiteral("Scoring round leaders are:");
-
     // Logging - Main Runoff
     static inline const QString LOG_EVENT_RUNOFF_CANDIDATES = QStringLiteral(R"("%1" & "%2" advance to the runoff.)");
     static inline const QString LOG_EVENT_PERFORM_PRIMARY_RUNOFF = QStringLiteral("Performing primary runoff...");

--- a/lib/include/star/calculator.h
+++ b/lib/include/star/calculator.h
@@ -25,7 +25,8 @@ public:
     {
         NoOptions = 0x00,
         AllowTrueTies = 0x01,
-        CondorcetProtocol = 0x02
+        CondorcetProtocol = 0x02,
+        DefactoWinner = 0x04
     };
     Q_DECLARE_FLAGS(Options, Option);
 
@@ -53,9 +54,14 @@ private:
         "Overflow: {%4}\n"
     );
 
-    // Logging - Main Runoff
-    static inline const QString LOG_EVENT_RUNOFF_CANDIDATES = QStringLiteral(R"("%1" & "%2" advance to the runoff.)");
-    static inline const QString LOG_EVENT_PERFORM_PRIMARY_RUNOFF = QStringLiteral("Performing primary runoff...");
+    // Logging - Defacto Winner Check
+    static inline const QString LOG_EVENT_DEFACTO_WINNER_CHECK = QStringLiteral(R"(Simulating runoff for potential defacto winner "%1" between:)");
+    static inline const QString LOG_EVENT_DEFACTO_WINNER_CHECK_WIN = QStringLiteral(R"(The first seed won against "%1".)");
+    static inline const QString LOG_EVENT_DEFACTO_WINNER_CHECK_FAIL = QStringLiteral(R"(The first seed lost to "%1".)");
+    static inline const QString LOG_EVENT_DEFACTO_WINNER_CHECK_SUCCESS = QStringLiteral("The first seed wins all simulated runoffs.");
+
+    // Logging - Runoff
+    static inline const QString LOG_EVENT_RUNOFF = QStringLiteral(R"(Observing runoff between "%1" and "%2".)");
     static inline const QString LOG_EVENT_RUNOFF_HEAD_TO_HEAD_WINNER_CHECK = QStringLiteral("Checking for clear winner of head-to-head.");
     static inline const QString LOG_EVENT_RUNOFF_TIE = QStringLiteral("The candidates in the runoff are tied in terms of preference.");
     static inline const QString LOG_EVENT_RUNOFF_HIGHER_SCORE_CHECK = QStringLiteral("Checking for the candidate with the higher score.");
@@ -86,7 +92,10 @@ private:
     // Logging - Main
     static inline const QString LOG_EVENT_FILLING_SEAT = QStringLiteral("Filling seat %1...");
     static inline const QString LOG_EVENT_DIRECT_SEAT_FILL = QStringLiteral("Only one candidate remains, seat can be filled directly.");
+    static inline const QString LOG_EVENT_RUNOFF_CANDIDATES = QStringLiteral(R"("%1" & "%2" advance to the runoff.)");
     static inline const QString LOG_EVENT_NO_RUNOFF = QStringLiteral("The number of candidates could not be narrowed to two in order to perform the runoff.");
+    static inline const QString LOG_EVENT_DEFACTO_WINNER_SEAT_FILL = QStringLiteral(R"(Filling seat with defacto winner "%1")");
+    static inline const QString LOG_EVENT_PERFORM_PRIMARY_RUNOFF = QStringLiteral("Performing primary runoff...");
 
     // Logging - Final Results
     static inline const QString LOG_EVENT_FINAL_RESULTS = QStringLiteral(
@@ -133,7 +142,8 @@ public:
 private:
     // Main steps
     QualifierResult performRunoffQualifier(const QList<Rank>& scoreRankings) const;
-    QString performPrimaryRunoff(QPair<QString, QString> candidates) const;
+    bool checkForDefactoWinner(const QString& firstSeed, const QSet<QString>& overflow) const;
+    QString performRunoff(std::pair<QString, QString> candidates) const;
 
     // Utility
     QList<Rank> rankByScore(const QSet<QString>& candidates, Rank::Order order) const;

--- a/lib/include/star/electionresult.h
+++ b/lib/include/star/electionresult.h
@@ -5,6 +5,7 @@
 
 // Project Includes
 #include "star/election.h"
+#include "star/seat.h"
 
 namespace Star
 {
@@ -14,22 +15,26 @@ class ElectionResult
 //-Instance Variables--------------------------------------------------------------------------------------------------
 private:
     const Election* mElection;
-    QStringList mWinners;
-    QSet<QString> mUnresolvedCandidates;
+    QList<Seat> mSeats;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
     ElectionResult();
-    ElectionResult(const Election* election, const QStringList& winners, const QSet<QString> unresolved);
+    ElectionResult(const Election* election, const QList<Seat>& seats);
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     bool isNull() const;
     bool isComplete() const;
+
+    const Seat& seatAt(qsizetype i) const;
+    QList<Seat> seats() const;
     QStringList winners() const;
     QSet<QString> unresolvedCandidates() const;
-    int filledSeatCount() const;
-    int unfilledSeatCount() const;
+    Seat unresolvedSeat() const;
+    qsizetype seatCount() const;
+    qsizetype filledSeatCount() const;
+    qsizetype unfilledSeatCount() const;
     const Election* election() const;
 
     bool operator==(const ElectionResult& other) const;

--- a/lib/include/star/expectedelectionresult.h
+++ b/lib/include/star/expectedelectionresult.h
@@ -12,28 +12,46 @@ namespace Star
 
 class ExpectedElectionResult
 {
+//-Inner Classes----------------------------------------------------------------------------------------------------
+public:
+    class Builder;
+
 //-Instance Variables--------------------------------------------------------------------------------------------------
 private:
-    QStringList mWinners;
-    QSet<QString> mUnresolvedCandidates;
+    QList<Seat> mSeats;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
     ExpectedElectionResult();
-    ExpectedElectionResult(const QStringList& winners, const QSet<QString> unresolved = {});
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     bool isNull() const;
+    bool sameOutcomeAs(const ElectionResult& result);
 
-    QStringList winners() const;
-    QSet<QString> unresolvedCandidates() const;
-
-    void setWinners(const QStringList& winners);
-    void setUnresolvedCandidates(QSet<QString> unresolved);
+    qsizetype seatCount() const;
+    QList<Seat> seats() const;
 
     bool operator==(const ElectionResult& result) const;
     bool operator!=(const ElectionResult& result) const;
+};
+
+class ExpectedElectionResult::Builder
+{
+//-Instance Variables--------------------------------------------------------------------------------------------------
+private:
+    ExpectedElectionResult mConstruct;
+
+//-Constructor---------------------------------------------------------------------------------------------------------
+public:
+    Builder();
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+public:
+    Builder& wSeat(const Seat& seat);
+    Builder& wWinner(const QString& winner);
+
+    ExpectedElectionResult build();
 };
 
 }

--- a/lib/include/star/qualifierresult.h
+++ b/lib/include/star/qualifierresult.h
@@ -17,21 +17,25 @@ private:
     QString mFirstSeed;
     QString mSecondSeed;
     QSet<QString> mOverflow;
+    bool mSimultaneous;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
 public:
     QualifierResult();
-    QualifierResult(const QString& f, const QString& s, const QSet<QString>& o);
+    QualifierResult(const QSet<QString>& firstAdv, const QSet<QString>& secondAdv = {});
+    QualifierResult(const QString& f, const QString& s, bool sim, const QSet<QString>& o);
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 public:
     bool isNull() const;
     bool isComplete() const;
+    bool isSeededSimultaneously() const;
 
     QString firstSeed() const;
     QString secondSeed() const;
     std::pair<QString, QString> seeds();
     QSet<QString> overflow() const;
+    QSet<QString> unresolved() const;
 
     bool operator==(const QualifierResult& other) const;
     bool operator!=(const QualifierResult& other) const;

--- a/lib/include/star/qualifierresult.h
+++ b/lib/include/star/qualifierresult.h
@@ -30,6 +30,8 @@ public:
     bool isNull() const;
     bool isComplete() const;
     bool isSeededSimultaneously() const;
+    bool hasFirstSeed() const;
+    bool hasSecondSeed() const;
 
     QString firstSeed() const;
     QString secondSeed() const;

--- a/lib/include/star/qualifierresult.h
+++ b/lib/include/star/qualifierresult.h
@@ -1,0 +1,42 @@
+#ifndef QUALIFIERRESULT_H
+#define QUALIFIERRESULT_H
+
+// Qt Includes
+#include <QSet>
+#include <QString>
+
+namespace Star
+{
+
+class QualifierResult
+{
+friend class Calculator;
+
+//-Instance Variables--------------------------------------------------------------------------------------------------
+private:
+    QString mFirstSeed;
+    QString mSecondSeed;
+    QSet<QString> mOverflow;
+
+//-Constructor---------------------------------------------------------------------------------------------------------
+public:
+    QualifierResult();
+    QualifierResult(const QString& f, const QString& s, const QSet<QString>& o);
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+public:
+    bool isNull() const;
+    bool isComplete() const;
+
+    QString firstSeed() const;
+    QString secondSeed() const;
+    std::pair<QString, QString> seeds();
+    QSet<QString> overflow() const;
+
+    bool operator==(const QualifierResult& other) const;
+    bool operator!=(const QualifierResult& other) const;
+};
+
+}
+
+#endif // QUALIFIERRESULT_H

--- a/lib/include/star/seat.h
+++ b/lib/include/star/seat.h
@@ -1,0 +1,42 @@
+#ifndef SEAT_H
+#define SEAT_H
+
+// Qt Includes
+#include <QObject>
+#include <QFlags>
+
+// Project Includes
+#include "star/qualifierresult.h"
+
+namespace Star
+{
+
+class Seat
+{
+//-Instance Variables--------------------------------------------------------------------------------------------------
+private:
+    QString mWinner;
+    QualifierResult mQualifierResult;
+
+//-Constructor---------------------------------------------------------------------------------------------------------
+public:
+    Seat();
+    Seat(const QualifierResult& qualifierResult);
+    Seat(const QString& winner, const QualifierResult& qualifierResult = QualifierResult());
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+public:
+    bool isNull() const;
+    bool isFilled() const;
+    bool isExceptionFilled() const;
+
+    QString winner() const;
+    QualifierResult qualifierResult() const;
+
+    bool operator==(const Seat& other) const;
+    bool operator!=(const Seat& other) const;
+};
+
+}
+
+#endif // SEAT_H

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -38,51 +38,6 @@ Calculator::~Calculator() = default;
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 //Private:
-QString Calculator::performPrimaryRunoff(QPair<QString, QString> candidates) const
-{
-    emit calculationDetail(LOG_EVENT_PERFORM_PRIMARY_RUNOFF);
-
-    // Check for clear winner
-    emit calculationDetail(LOG_EVENT_RUNOFF_HEAD_TO_HEAD_WINNER_CHECK);
-    QString winner = mHeadToHeadResults->winner(candidates.first, candidates.second);
-    if(winner.isNull())
-    {
-        emit calculationDetail(LOG_EVENT_RUNOFF_TIE);
-        QSet<QString> cTied = {candidates.first, candidates.second};
-
-        // Try to break tie by original score
-        emit calculationDetail(LOG_EVENT_RUNOFF_HIGHER_SCORE_CHECK);
-        QSet<QString> highestScore = breakTieHighestScore(cTied);
-        if(highestScore.size() == 1)
-            winner = *highestScore.cbegin();
-        else
-        {
-            // Try to break tie by five star votes
-            emit calculationDetail(LOG_EVENT_RUNOFF_MORE_FIVE_STAR_CHECK);
-            QSet<QString> mostFiveStar = breakTieMostFiveStar(cTied);
-            if(mostFiveStar.size() == 1)
-                winner = *mostFiveStar.cbegin();
-            else
-            {
-                // Randomly choose a winner if allowed
-                if(!mOptions.testFlag(Option::AllowTrueTies))
-                {
-                    emit calculationDetail(LOG_EVENT_RUNOFF_CHOOSING_RANDOM_WINNER);
-                    winner = breakTieRandom(cTied);
-                }
-                else
-                    emit calculationDetail(LOG_EVENT_RUNOFF_NO_RANDOM);
-            }
-        }
-    }
-
-    // Note results
-    emit calculationDetail(winner.isNull() ? LOG_EVENT_RUNOFF_UNRESOLVED : LOG_EVENT_RUNOFF_WINNER.arg(winner));
-
-    // Return result
-    return winner;
-}
-
 QualifierResult Calculator::performRunoffQualifier(const QList<Rank>& scoreRankings) const
 {
     /* Overall this function attempts to break the tied candidates by selecting the winner(s) of the tie in
@@ -282,6 +237,51 @@ QualifierResult Calculator::performRunoffQualifier(const QList<Rank>& scoreRanki
     // Return the qualifier result set, ideally complete
     logQualifierResult(res);
     return res;
+}
+
+QString Calculator::performPrimaryRunoff(QPair<QString, QString> candidates) const
+{
+    emit calculationDetail(LOG_EVENT_PERFORM_PRIMARY_RUNOFF);
+
+    // Check for clear winner
+    emit calculationDetail(LOG_EVENT_RUNOFF_HEAD_TO_HEAD_WINNER_CHECK);
+    QString winner = mHeadToHeadResults->winner(candidates.first, candidates.second);
+    if(winner.isNull())
+    {
+        emit calculationDetail(LOG_EVENT_RUNOFF_TIE);
+        QSet<QString> cTied = {candidates.first, candidates.second};
+
+        // Try to break tie by original score
+        emit calculationDetail(LOG_EVENT_RUNOFF_HIGHER_SCORE_CHECK);
+        QSet<QString> highestScore = breakTieHighestScore(cTied);
+        if(highestScore.size() == 1)
+            winner = *highestScore.cbegin();
+        else
+        {
+            // Try to break tie by five star votes
+            emit calculationDetail(LOG_EVENT_RUNOFF_MORE_FIVE_STAR_CHECK);
+            QSet<QString> mostFiveStar = breakTieMostFiveStar(cTied);
+            if(mostFiveStar.size() == 1)
+                winner = *mostFiveStar.cbegin();
+            else
+            {
+                // Randomly choose a winner if allowed
+                if(!mOptions.testFlag(Option::AllowTrueTies))
+                {
+                    emit calculationDetail(LOG_EVENT_RUNOFF_CHOOSING_RANDOM_WINNER);
+                    winner = breakTieRandom(cTied);
+                }
+                else
+                    emit calculationDetail(LOG_EVENT_RUNOFF_NO_RANDOM);
+            }
+        }
+    }
+
+    // Note results
+    emit calculationDetail(winner.isNull() ? LOG_EVENT_RUNOFF_UNRESOLVED : LOG_EVENT_RUNOFF_WINNER.arg(winner));
+
+    // Return result
+    return winner;
 }
 
 QList<Rank> Calculator::rankByScore(const QSet<QString>& candidates, Rank::Order order) const

--- a/lib/src/calculator.cpp
+++ b/lib/src/calculator.cpp
@@ -543,7 +543,7 @@ ElectionResult Calculator::calculateResult()
     mHeadToHeadResults = std::make_unique<HeadToHeadResults>(mElection);
 
     // Results holder
-    QList<Seat> filledSeats;
+    QList<Seat> processedSeats;
 
     // Active candidate rankings
     QList<Rank> candidateRankings = mElection->scoreRankings();
@@ -559,7 +559,7 @@ ElectionResult Calculator::calculateResult()
             if(frontCandidates.size() == 1)
             {
                 emit calculationDetail(LOG_EVENT_DIRECT_SEAT_FILL);
-                filledSeats.append(Seat(*frontCandidates.cbegin()));
+                processedSeats.append(Seat(*frontCandidates.cbegin()));
                 break;
             }
         }
@@ -573,7 +573,7 @@ ElectionResult Calculator::calculateResult()
         if(!runoffQualifier.isComplete())
         {
             emit calculationDetail(LOG_EVENT_NO_RUNOFF);
-            filledSeats.append(runoffQualifier);
+            processedSeats.append(runoffQualifier);
             break;
         }
 
@@ -585,12 +585,12 @@ ElectionResult Calculator::calculateResult()
         // Check for unresolved runoff tie
         if(seatWinner.isNull())
         {
-            filledSeats.append(runoffQualifier);
+            processedSeats.append(runoffQualifier);
             break;
         }
 
         // Record seat winner
-        filledSeats.append(Seat(seatWinner, runoffQualifier));
+        processedSeats.append(Seat(seatWinner, runoffQualifier));
 
         /* Remove seat winner from remaining rankings
          *
@@ -616,7 +616,7 @@ ElectionResult Calculator::calculateResult()
         }
     }
 
-    ElectionResult finalResults(mElection, filledSeats);
+    ElectionResult finalResults(mElection, processedSeats);
 
     // Note final results
     logElectionResults(finalResults);

--- a/lib/src/electionresult.cpp
+++ b/lib/src/electionresult.cpp
@@ -59,7 +59,7 @@ qsizetype ElectionResult::filledSeatCount() const
     if(isNull())
         return 0;
 
-    int count = mSeats.size();
+    qsizetype count = mSeats.size();
     if(mSeats.back().winner().isNull())
         count--;
 

--- a/lib/src/electionresult.cpp
+++ b/lib/src/electionresult.cpp
@@ -12,29 +12,67 @@ namespace Star
 //Public:
 ElectionResult::ElectionResult() :
     mElection(nullptr),
-    mWinners(),
-    mUnresolvedCandidates()
+    mSeats()
 {}
 
-ElectionResult::ElectionResult(const Election* election, const QStringList& winners, const QSet<QString> unresolved) :
+ElectionResult::ElectionResult(const Election* election, const QList<Seat>& seats) :
     mElection(election),
-    mWinners(winners),
-    mUnresolvedCandidates(unresolved)
+    mSeats(seats)
 {}
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 //Public:
-bool ElectionResult::isNull() const { return !mElection || (mWinners.isEmpty() && mUnresolvedCandidates.isEmpty()); }
-bool ElectionResult::isComplete() const { return mUnresolvedCandidates.isEmpty(); }
-QStringList ElectionResult::winners() const { return mWinners; }
-QSet<QString> ElectionResult::unresolvedCandidates() const { return mUnresolvedCandidates; }
-int ElectionResult::filledSeatCount() const { return mWinners.size(); }
-int ElectionResult::unfilledSeatCount() const { return mElection ? mElection->seatCount() - mWinners.size() : 0; }
+bool ElectionResult::isNull() const { return !mElection || mSeats.isEmpty(); }
+bool ElectionResult::isComplete() const { return !isNull() && unfilledSeatCount() == 0; }
+
+const Seat& ElectionResult::seatAt(qsizetype i) const
+{
+    Q_ASSERT_X(size_t(i) < size_t(mSeats.size()), "ElectionResult::at", "index out of range");
+
+    return mSeats.at(i);
+}
+
+QList<Seat> ElectionResult::seats() const { return mSeats; }
+
+QStringList ElectionResult::winners() const
+{
+    QStringList wrs;
+    for(const Seat& seat : mSeats)
+        if(!seat.winner().isNull()) // Only the last can be null
+            wrs.append(seat.winner());
+
+    return wrs;
+}
+
+QSet<QString> ElectionResult::unresolvedCandidates() const
+{
+    if(isNull() || isComplete())
+        return QSet<QString>();
+    else
+        return mSeats.back().qualifierResult().unresolved();
+}
+
+qsizetype ElectionResult::seatCount() const { return mSeats.size(); }
+
+qsizetype ElectionResult::filledSeatCount() const
+{
+    if(isNull())
+        return 0;
+
+    int count = mSeats.size();
+    if(mSeats.back().winner().isNull())
+        count--;
+
+    return count;
+}
+
+qsizetype ElectionResult::unfilledSeatCount() const { return !isNull() ? mElection->seatCount() - filledSeatCount() : 0; }
+
 const Election* ElectionResult::election() const { return mElection; }
 
 bool ElectionResult::operator==(const ElectionResult& other) const
 {
-    return mElection == other.mElection && mWinners == other.mWinners && mUnresolvedCandidates == other.mUnresolvedCandidates;
+    return mElection == other.mElection && mSeats == other.mSeats;
 }
 
 bool ElectionResult::operator!=(const ElectionResult& other) const { return !(*this == other); }

--- a/lib/src/expectedelectionresult.cpp
+++ b/lib/src/expectedelectionresult.cpp
@@ -11,29 +11,61 @@ namespace Star
 //-Constructor---------------------------------------------------------------------------------------------------------
 //Public:
 ExpectedElectionResult::ExpectedElectionResult() :
-    mWinners(),
-    mUnresolvedCandidates()
-{}
-
-ExpectedElectionResult::ExpectedElectionResult(const QStringList& winners, const QSet<QString> unresolved) :
-    mWinners(winners),
-    mUnresolvedCandidates(unresolved)
+    mSeats()
 {}
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 //Public:
-bool ExpectedElectionResult::isNull() const { return mWinners.isEmpty(); }
-QStringList ExpectedElectionResult::winners() const { return mWinners; }
-QSet<QString> ExpectedElectionResult::unresolvedCandidates() const { return mUnresolvedCandidates; }
+bool ExpectedElectionResult::isNull() const { return mSeats.isEmpty(); }
 
-void ExpectedElectionResult::setWinners(const QStringList& winner) { mWinners = winner; }
-void ExpectedElectionResult::setUnresolvedCandidates(QSet<QString> unresolved) { mUnresolvedCandidates = unresolved; }
+bool ExpectedElectionResult::sameOutcomeAs(const ElectionResult& result)
+{
+    if(mSeats.size() != result.seatCount())
+        return false;
+    else
+    {
+        for(auto s = 0; s != mSeats.size(); s++)
+            if(mSeats.at(s).winner() != result.seatAt(s).winner())
+                return false;
+
+        return true;
+    }
+}
+
+qsizetype ExpectedElectionResult::seatCount() const { return mSeats.size(); }
+QList<Seat> ExpectedElectionResult::seats() const { return mSeats; }
 
 bool ExpectedElectionResult::operator==(const ElectionResult& result) const
 {
-    return result.winners() == mWinners && result.unresolvedCandidates() == mUnresolvedCandidates;
+    return mSeats == result.seats();
 }
 
 bool ExpectedElectionResult::operator!=(const ElectionResult& result) const { return !(*this == result); }
+
+//===============================================================================================================
+// ExpectedElectionResult::Builder
+//===============================================================================================================
+
+//-Constructor--------------------------------------------------------------------------------------------------------
+//Public:
+ExpectedElectionResult::Builder::Builder() {}
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+//Public:
+ExpectedElectionResult::Builder& ExpectedElectionResult::Builder::wSeat(const Seat& seat)
+{
+    mConstruct.mSeats.append(seat); return *this;
+}
+
+ExpectedElectionResult::Builder& ExpectedElectionResult::Builder::wWinner(const QString& winner)
+{
+    mConstruct.mSeats.append(Seat(winner)); return *this;
+}
+
+ExpectedElectionResult ExpectedElectionResult::Builder::build()
+{
+    // Return completed construct
+    return mConstruct;
+}
 
 }

--- a/lib/src/headtoheadresults.cpp
+++ b/lib/src/headtoheadresults.cpp
@@ -12,6 +12,9 @@ namespace Star
 //===============================================================================================================
 
 //-Constructor---------------------------------------------------------------------------------------------------------
+//Private:
+HeadToHeadResults::HeadToHeadResults() {}
+
 //Public:
 HeadToHeadResults::HeadToHeadResults(const Election* election)
 {
@@ -120,7 +123,7 @@ void HeadToHeadResults::narrow(QSet<QString> candidates, NarrowMode mode)
 {
     auto shouldCull = [&](const QString& c){
         return candidates.contains(c) && mode == Exclusive ||
-              !candidates.contains(c) && mode == Inclusive;
+               !candidates.contains(c) && mode == Inclusive;
     };
 
     auto sItr = mStats.begin();
@@ -137,7 +140,6 @@ void HeadToHeadResults::narrow(QSet<QString> candidates, NarrowMode mode)
         stat.defeats.removeIf([&](const QString& c){ return shouldCull(c); });
         stat.victories.removeIf([&](const QString& c) { return shouldCull(c); });
 
-        // NOTE: Getting list from preferences is fine because the list should always be the same for pref and anti-pref
         Q_ASSERT(stat.preferences.count() == stat.antiPreferences.count());
         QList<QString> cans = stat.preferences.components();
         for(const QString& c : cans)
@@ -153,9 +155,53 @@ void HeadToHeadResults::narrow(QSet<QString> candidates, NarrowMode mode)
 
 HeadToHeadResults HeadToHeadResults::narrowed(QSet<QString> candidates, NarrowMode mode)
 {
-    HeadToHeadResults cpy(*this);
-    cpy.narrow(candidates, mode);
-    return cpy;
+    /* NOTE: Starts with an empty copy, then only fills it with the narrowed candidates, which is optimal
+     * for memory usage; however, this is also slower as there are several memory allocations involved
+     * instead of just one. The following is worse for memory but better for speed:
+     *
+     * HeadToHeadResults narrowedCopy(*this);
+     * narrowedCopy.narrow(candidates, mode);
+     * return narrowedCopy;
+     */
+
+    HeadToHeadResults narrowedCopy;
+
+    auto shouldCopy = [&](const QString& c){
+        return !candidates.contains(c) && mode == Exclusive ||
+               candidates.contains(c) && mode == Inclusive;
+    };
+
+    for(auto sItr = mStats.cbegin(); sItr != mStats.cend(); sItr++)
+    {
+        QString canA = sItr.key();
+
+        if(!shouldCopy(canA))
+            continue;
+
+        const CandidateStats& stat = *sItr;
+
+        for(const QString& canB : stat.victories)
+            if(shouldCopy(canB))
+                narrowedCopy.mStats[canA].victories.insert(canB);
+
+
+        for(const QString& canB : stat.defeats)
+            if(shouldCopy(canB))
+                narrowedCopy.mStats[canA].defeats.insert(canB);
+
+        Q_ASSERT(stat.preferences.count() == stat.antiPreferences.count());
+        QList<QString> prefCans = stat.preferences.components();
+        for(const QString& canB : prefCans)
+        {
+            if(shouldCopy(canB))
+            {
+                narrowedCopy.mStats[canA].preferences.insert(canB, stat.preferences.value(canB));
+                narrowedCopy.mStats[canA].antiPreferences.insert(canB, stat.antiPreferences.value(canB));
+            }
+        }
+    }
+
+    return narrowedCopy;
 }
 
 }

--- a/lib/src/headtoheadresults.h
+++ b/lib/src/headtoheadresults.h
@@ -36,6 +36,9 @@ private:
     QHash<QString, CandidateStats> mStats;
 
 //-Constructor---------------------------------------------------------------------------------------------------------
+private:
+    HeadToHeadResults();
+
 public:
     HeadToHeadResults(const Election* election);
 

--- a/lib/src/qualifierresult.cpp
+++ b/lib/src/qualifierresult.cpp
@@ -1,0 +1,42 @@
+// Unit Include
+#include "star/qualifierresult.h"
+
+namespace Star
+{
+
+//===============================================================================================================
+// QualifierResult
+//===============================================================================================================
+
+//-Constructor---------------------------------------------------------------------------------------------------------
+//Public:
+QualifierResult::QualifierResult() :
+    mFirstSeed(),
+    mSecondSeed(),
+    mOverflow()
+{}
+
+QualifierResult::QualifierResult(const QString& f, const QString& s, const QSet<QString>& o) :
+    mFirstSeed(f),
+    mSecondSeed(s),
+    mOverflow(o)
+{}
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+//Public:
+bool QualifierResult::isNull() const { return mFirstSeed.isNull() && mSecondSeed.isNull() && mOverflow.isEmpty(); }
+bool QualifierResult::isComplete() const { return !mFirstSeed.isEmpty() && !mSecondSeed.isEmpty() && mOverflow.isEmpty();}
+
+QString QualifierResult::firstSeed() const { return mFirstSeed; }
+QString QualifierResult::secondSeed() const { return mSecondSeed; }
+std::pair<QString, QString> QualifierResult::seeds() { return std::make_pair(mFirstSeed, mSecondSeed); }
+QSet<QString> QualifierResult::overflow() const { return mOverflow; }
+
+bool QualifierResult::operator==(const QualifierResult& result) const
+{
+    return result.firstSeed() == mFirstSeed && result.secondSeed() == mSecondSeed && result.overflow() == mOverflow;
+}
+
+bool QualifierResult::operator!=(const QualifierResult& result) const { return !(*this == result); }
+
+}

--- a/lib/src/qualifierresult.cpp
+++ b/lib/src/qualifierresult.cpp
@@ -65,6 +65,8 @@ QualifierResult::QualifierResult(const QSet<QString>& firstAdv, const QSet<QStri
 bool QualifierResult::isNull() const { return mFirstSeed.isNull() && mSecondSeed.isNull() && mOverflow.isEmpty(); }
 bool QualifierResult::isComplete() const { return !mFirstSeed.isEmpty() && !mSecondSeed.isEmpty() && mOverflow.isEmpty();}
 bool QualifierResult::isSeededSimultaneously() const { return mSimultaneous; }
+bool QualifierResult::hasFirstSeed() const { return !mFirstSeed.isNull(); }
+bool QualifierResult::hasSecondSeed() const { return !mSecondSeed.isNull(); }
 
 QString QualifierResult::firstSeed() const { return mFirstSeed; }
 QString QualifierResult::secondSeed() const { return mSecondSeed; }

--- a/lib/src/qualifierresult.cpp
+++ b/lib/src/qualifierresult.cpp
@@ -13,28 +13,90 @@ namespace Star
 QualifierResult::QualifierResult() :
     mFirstSeed(),
     mSecondSeed(),
-    mOverflow()
+    mOverflow(),
+    mSimultaneous(false)
 {}
 
-QualifierResult::QualifierResult(const QString& f, const QString& s, const QSet<QString>& o) :
-    mFirstSeed(f),
-    mSecondSeed(s),
-    mOverflow(o)
-{}
+QualifierResult::QualifierResult(const QString& f, const QString& s, bool sim, const QSet<QString>& o)
+{
+    // Cover all valid qualifier outcome types
+    if((f.isNull() && s.isNull() && !sim && o.size() > 2) || // Unresolvable tie for 1st seed
+       (!f.isNull() && s.isNull() && !sim && o.size() > 1) || // Unresolvable tie for 2nd seed
+       (!f.isNull() && !s.isNull() && o.isEmpty())) // Simultaneous or separate fill of both seeds
+    {
+        mFirstSeed = f;
+        mSecondSeed = s;
+        mSimultaneous = sim;
+        mOverflow = o;
+    }
+
+    // Leave instance null if the input was invalid
+}
+
+QualifierResult::QualifierResult(const QSet<QString>& firstAdv, const QSet<QString>& secondAdv) :
+    mSimultaneous(false)
+{
+    // Cover all valid qualifier outcome types
+    if(firstAdv.size() == 2 && secondAdv.isEmpty()) // Simultaneous fill of both seeds
+    {
+        auto fItr = firstAdv.cbegin();
+        mFirstSeed = *(fItr++);
+        mSecondSeed = *fItr;
+        mSimultaneous = true;
+    }
+    else if(firstAdv.size() > 2 && secondAdv.isEmpty()) // Unresolvable tie for 1st seed
+        mOverflow = firstAdv;
+    else if(firstAdv.size() == 1 && secondAdv.size() > 1) // Unresolvable tie for 2nd seed
+    {
+        mFirstSeed = *firstAdv.cbegin();
+        mOverflow = secondAdv;
+    }
+    else if(firstAdv.size() == 1 && secondAdv.size() == 1) // Separate fill of both seeds
+    {
+        mFirstSeed = *firstAdv.cbegin();
+        mSecondSeed = *secondAdv.cbegin();
+    }
+
+    // Leave instance null if the input was invalid
+}
 
 //-Instance Functions-------------------------------------------------------------------------------------------------
 //Public:
 bool QualifierResult::isNull() const { return mFirstSeed.isNull() && mSecondSeed.isNull() && mOverflow.isEmpty(); }
 bool QualifierResult::isComplete() const { return !mFirstSeed.isEmpty() && !mSecondSeed.isEmpty() && mOverflow.isEmpty();}
+bool QualifierResult::isSeededSimultaneously() const { return mSimultaneous; }
 
 QString QualifierResult::firstSeed() const { return mFirstSeed; }
 QString QualifierResult::secondSeed() const { return mSecondSeed; }
 std::pair<QString, QString> QualifierResult::seeds() { return std::make_pair(mFirstSeed, mSecondSeed); }
 QSet<QString> QualifierResult::overflow() const { return mOverflow; }
 
+QSet<QString> QualifierResult::unresolved() const
+{
+    if(isNull() || isComplete())
+        return QSet<QString>();
+    else
+    {
+        QSet<QString> unr = mOverflow;
+        if(!mFirstSeed.isNull())
+            unr.insert(mFirstSeed);
+
+        return unr;
+    }
+}
+
 bool QualifierResult::operator==(const QualifierResult& result) const
 {
-    return result.firstSeed() == mFirstSeed && result.secondSeed() == mSecondSeed && result.overflow() == mOverflow;
+    if(mOverflow != result.overflow() || mSimultaneous != result.isSeededSimultaneously())
+        return false;
+
+    if(mSimultaneous)
+    {
+        return (result.firstSeed() == mFirstSeed && result.secondSeed() == mSecondSeed) ||
+               (result.firstSeed() == mSecondSeed && result.secondSeed() == mFirstSeed);
+    }
+    else
+        return result.firstSeed() == mFirstSeed && result.secondSeed() == mSecondSeed;
 }
 
 bool QualifierResult::operator!=(const QualifierResult& result) const { return !(*this == result); }

--- a/lib/src/reference/resultset_p.h
+++ b/lib/src/reference/resultset_p.h
@@ -18,14 +18,17 @@ class ResultSetReader
 //-Class Variables--------------------------------------------------------------------------------------------------
 private:
     // Keys
-    static inline const QString KEY_WINNERS_ARRAY = QStringLiteral("winners");
-    static inline const QString KEY_UNRESOLVED_ARRAY = QStringLiteral("unresolved");
+    static inline const QString KEY_WINNER_STR = QStringLiteral("winner");
+    static inline const QString KEY_QUALIFIER_OBJ = QStringLiteral("qualifier");
+    static inline const QString KEY_QUALIFIER_FIRST_ADV_ARRAY = QStringLiteral("firstAdv");
+    static inline const QString KEY_QUALIFIER_SECOND_ADV_ARRAY = QStringLiteral("secondAdv");
 
     // Errors
     static inline const QString MAIN_ERR_MSG = QStringLiteral("Error reading results set.");
 
     static inline const QString ERR_WRONG_ROOT_TYPE = QStringLiteral("Root item is not an array.");
-    static inline const QString ERR_WRONG_ARRAY_ITEM_TYPE = QStringLiteral("Root array did not contain objects.");
+    static inline const QString ERR_WRONG_ROOT_ARRAY_ITEM_TYPE = QStringLiteral("Root array did not contain other arrays.");
+    static inline const QString ERR_WRONG_SEAT_ARRAY_ITEM_TYPE = QStringLiteral("Seat array did not contain objects.");
 
     static inline const Qx::GenericError ERROR_TEMPLATE = Qx::GenericError(Qx::GenericError::Critical, MAIN_ERR_MSG);
 

--- a/lib/src/seat.cpp
+++ b/lib/src/seat.cpp
@@ -1,0 +1,45 @@
+// Unit Include
+#include "star/seat.h"
+
+namespace Star
+{
+
+//===============================================================================================================
+// Seat
+//===============================================================================================================
+
+//-Constructor---------------------------------------------------------------------------------------------------------
+//Public:
+Seat::Seat() :
+    mWinner(),
+    mQualifierResult()
+{}
+
+Seat::Seat(const QualifierResult& qualifierResult) :
+    mWinner(),
+    mQualifierResult(qualifierResult)
+{}
+
+Seat::Seat(const QString& winner, const QualifierResult& qualifierResult) :
+    mWinner(winner),
+    mQualifierResult(qualifierResult)
+{}
+
+
+//-Instance Functions-------------------------------------------------------------------------------------------------
+//Public:
+bool Seat::isNull() const { return mWinner.isNull() && mQualifierResult.isNull(); }
+bool Seat::isFilled() const { return !mWinner.isNull(); }
+bool Seat::isExceptionFilled() const { return !isNull() && mQualifierResult.isNull(); } // NOTE: Filled without runoff
+
+QString Seat::winner() const { return mWinner; }
+QualifierResult Seat::qualifierResult() const { return mQualifierResult; }
+
+bool Seat::operator==(const Seat& other) const
+{
+    return mWinner == other.winner() && mQualifierResult == other.qualifierResult();
+}
+
+bool Seat::operator!=(const Seat& other) const { return !(*this == other); }
+
+}

--- a/tests/full_reference_election/data/basic_election_sampler.json
+++ b/tests/full_reference_election/data/basic_election_sampler.json
@@ -1,74 +1,290 @@
 [
-  {
-    "winners": ["Sixth film", "Seventh film"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fourth Director", "Fifth Director"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fifth Cheesesteak", "Fourth Cheesesteak"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Sixth Actress", "Fifth Actress"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fifth Actor", "First Actor"],
-	"unresolved": []
-  },
-  {
-    "winners": ["First Supporting Actress", "Fourth Supporting Actress"],
-	"unresolved": []
-  },
-  {
-    "winners": ["First Supporting Actor", "Second Supporting Actor"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fifth Documentary", "Second Documentary"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Third Script"],
-	"unresolved": ["Second Script", "Fourth Script", "Fifth Script"]
-  },
-  {
-    "winners": ["Fifth Soundtrack", "Third Soundtrack"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fourth Directorial Debut", "Fifth Directorial Debut"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fourth Breakthrough", "First Breakthrough"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Fourth Cinematography", "Fifth Cinematography"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Second Foreign", "Fifth Foreign"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Second Animated", "First Animated"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Third Ensemble", "Second Ensemble"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Second Friedman", "Third Friedman"],
-	"unresolved": []
-  },
-  {
-    "winners": ["Second May", "First May"],
-	"unresolved": []
-  }
+  [
+    {
+      "winner": "Sixth film",
+      "qualifier": {
+        "firstAdv": ["Sixth film", "Eighth film"],
+        "secondAdv": []       
+      }
+    },
+    {
+      "winner": "Seventh film",
+      "qualifier": {
+        "firstAdv": ["Eighth film"],
+        "secondAdv": ["Seventh film"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fourth Director",
+      "qualifier": {
+        "firstAdv": ["Fourth Director"],
+        "secondAdv": ["Fifth Director"]       
+      }
+    },
+    {
+      "winner": "Fifth Director",
+      "qualifier": {
+        "firstAdv": ["Fifth Director"],
+        "secondAdv": ["Second Director"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fifth Cheesesteak",
+      "qualifier": {
+        "firstAdv": ["Fifth Cheesesteak"],
+        "secondAdv": ["Fourth Cheesesteak"]       
+      }
+    },
+    {
+      "winner": "Fourth Cheesesteak",
+      "qualifier": {
+        "firstAdv": ["Second Cheesesteak", "Fourth Cheesesteak"],
+        "secondAdv": []       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Sixth Actress",
+      "qualifier": {
+        "firstAdv": ["Sixth Actress"],
+        "secondAdv": ["Fifth Actress"]       
+      }
+    },
+    {
+      "winner": "Fifth Actress",
+      "qualifier": {
+        "firstAdv": ["Fifth Actress", "Second Actress"],
+        "secondAdv": []       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fifth Actor",
+      "qualifier": {
+        "firstAdv": ["Fifth Actor"],
+        "secondAdv": ["First Actor"]       
+      }
+    },
+    {
+      "winner": "First Actor",
+      "qualifier": {
+        "firstAdv": ["First Actor"],
+        "secondAdv": ["Third Actor"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "First Supporting Actress",
+      "qualifier": {
+        "firstAdv": ["First Supporting Actress"],
+        "secondAdv": ["Fourth Supporting Actress"]       
+      }
+    },
+    {
+      "winner": "Fourth Supporting Actress",
+      "qualifier": {
+        "firstAdv": ["Fourth Supporting Actress"],
+        "secondAdv": ["Second Supporting Actress"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "First Supporting Actor",
+      "qualifier": {
+        "firstAdv": ["First Supporting Actor"],
+        "secondAdv": ["Second Supporting Actor"]       
+      }
+    },
+    {
+      "winner": "Second Supporting Actor",
+      "qualifier": {
+        "firstAdv": ["Second Supporting Actor"],
+        "secondAdv": ["Fifth Supporting Actor"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fifth Documentary",
+      "qualifier": {
+        "firstAdv": ["Fifth Documentary"],
+        "secondAdv": ["Second Documentary"]       
+      }
+    },
+    {
+      "winner": "Second Documentary",
+      "qualifier": {
+        "firstAdv": ["Second Documentary", "Third Documentary"],
+        "secondAdv": []       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Third Script",
+      "qualifier": {
+        "firstAdv": ["Third Script"],
+        "secondAdv": ["Second Script"]       
+      }
+    },
+    {
+      "winner": "",
+      "qualifier": {
+        "firstAdv": ["Second Script"],
+        "secondAdv": ["Fifth Script", "Fourth Script"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fifth Soundtrack",
+      "qualifier": {
+        "firstAdv": ["Fifth Soundtrack", "Third Soundtrack"],
+        "secondAdv": []       
+      }
+    },
+    {
+      "winner": "Third Soundtrack",
+      "qualifier": {
+        "firstAdv": ["Third Soundtrack"],
+        "secondAdv": ["Fourth Soundtrack"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fourth Directorial Debut",
+      "qualifier": {
+        "firstAdv": ["Fourth Directorial Debut"],
+        "secondAdv": ["Fifth Directorial Debut"]       
+      }
+    },
+    {
+      "winner": "Fifth Directorial Debut",
+      "qualifier": {
+        "firstAdv": ["Fifth Directorial Debut"],
+        "secondAdv": ["Second Directorial Debut"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fourth Breakthrough",
+      "qualifier": {
+        "firstAdv": ["Fourth Breakthrough"],
+        "secondAdv": ["First Breakthrough"]       
+      }
+    },
+    {
+      "winner": "First Breakthrough",
+      "qualifier": {
+        "firstAdv": ["First Breakthrough"],
+        "secondAdv": ["Third Breakthrough"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Fourth Cinematography",
+      "qualifier": {
+        "firstAdv": ["Fourth Cinematography"],
+        "secondAdv": ["Fifth Cinematography"]       
+      }
+    },
+    {
+      "winner": "Fifth Cinematography",
+      "qualifier": {
+        "firstAdv": ["Fifth Cinematography"],
+        "secondAdv": ["First Cinematography"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Second Foreign",
+      "qualifier": {
+        "firstAdv": ["Second Foreign"],
+        "secondAdv": ["Fourth Foreign"]       
+      }
+    },
+    {
+      "winner": "Fifth Foreign",
+      "qualifier": {
+        "firstAdv": ["Fourth Foreign"],
+        "secondAdv": ["Fifth Foreign"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Second Animated",
+      "qualifier": {
+        "firstAdv": ["Second Animated"],
+        "secondAdv": ["First Animated"]       
+      }
+    },
+    {
+      "winner": "First Animated",
+      "qualifier": {
+        "firstAdv": ["First Animated"],
+        "secondAdv": ["Fifth Animated"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Third Ensemble",
+      "qualifier": {
+        "firstAdv": ["Third Ensemble"],
+        "secondAdv": ["Second Ensemble"]       
+      }
+    },
+    {
+      "winner": "Second Ensemble",
+      "qualifier": {
+        "firstAdv": ["Second Ensemble"],
+        "secondAdv": ["Fourth Ensemble"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Second Friedman",
+      "qualifier": {
+        "firstAdv": ["Second Friedman", "Third Friedman"],
+        "secondAdv": []       
+      }
+    },
+    {
+      "winner": "Third Friedman",
+      "qualifier": {
+        "firstAdv": ["Third Friedman"],
+        "secondAdv": ["First Friedman"]       
+      }
+    }
+  ],
+  [
+    {
+      "winner": "Second May",
+      "qualifier": {
+        "firstAdv": ["First May", "Second May"],
+        "secondAdv": []       
+      }
+    },
+    {
+      "winner": "First May",
+      "qualifier": {
+        "firstAdv": [],
+        "secondAdv": []       
+      }
+    }
+  ]
 ]

--- a/tests/ties/tst_ties.cpp
+++ b/tests/ties/tst_ties.cpp
@@ -84,7 +84,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate4, .score = 0}
             }
         },
-        Star::ExpectedElectionResult({candidate1}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate1, Star::QualifierResult({candidate1, candidate2})))
+               .build(),
         Star::Calculator::AllowTrueTies
     );
 
@@ -109,7 +111,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate4, .score = 4}
             }
         },
-        Star::ExpectedElectionResult({candidate1}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate1, Star::QualifierResult({candidate1, candidate2})))
+               .build(),
         Star::Calculator::AllowTrueTies
     );
 
@@ -134,7 +138,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate4, .score = 4}
             }
         },
-        Star::ExpectedElectionResult({candidate1}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate1, Star::QualifierResult({candidate1}, {candidate4})))
+               .build(),
         Star::Calculator::AllowTrueTies
     );
 
@@ -171,7 +177,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate4, .score = 0},
             }
         },
-        Star::ExpectedElectionResult({candidate4}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate4, Star::QualifierResult({candidate4}, {candidate2})))
+               .build(),
         Star::Calculator::AllowTrueTies
     );
 
@@ -213,7 +221,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate5, .score = 5}
             }
         },
-        Star::ExpectedElectionResult({candidate3}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate3, Star::QualifierResult({candidate3}, {candidate2})))
+               .build(),
         Star::Calculator::AllowTrueTies | Star::Calculator::CondorcetProtocol
     );
 
@@ -264,7 +274,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate5, .score = 0}
             }
         },
-        Star::ExpectedElectionResult({candidate5}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(candidate5, Star::QualifierResult({candidate5}, {candidate1})))
+               .build(),
         Star::Calculator::AllowTrueTies | Star::Calculator::CondorcetProtocol
     );
 
@@ -291,7 +303,9 @@ void tst_ties::all_tie_cases_data()
                 {.candidate = candidate4, .score = 3}
             }
         },
-        Star::ExpectedElectionResult({}, {candidate1, candidate2, candidate3}),
+        Star::ExpectedElectionResult::Builder()
+               .wSeat(Star::Seat(Star::QualifierResult({candidate3}, {candidate1, candidate2})))
+               .build(),
         Star::Calculator::AllowTrueTies
     );
 }


### PR DESCRIPTION
This overhaul does:
- Merge preliminary candidate determination and preliminary tie reduction into one function dubbed "runoff qualifier" that handles seeding candidates into the runoff
- Details regarding the order and outcome of candidate seeding are tracked through QualifierResult
- Added option "DefactorWinner". In the situation where there is a first seed for a runoff, but an unresolvable tie for second seed, this option simulates a runoff between the first seed and each of the candidates in the tie for second seed and then gives the win to the first seed if they win all of the simulations
- The app now uses a CSV calculator options switch instead of individual switches for each option